### PR TITLE
chore(cas): Cleanup logger to prepare it to be its own package

### DIFF
--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -1,23 +1,8 @@
-import { Logger, LoggerModes } from '@overnightjs/logger';
-import * as logfmt from 'logfmt';
 import morgan from 'morgan';
 import { config } from 'node-config-ts';
 import path from 'path';
-import util from 'util';
 import { RotatingFileStream } from './stream-helpers';
-
-enum LogStyle {
-  info = 'info',
-  imp = 'imp',
-  warn = 'warn',
-  err = 'err'
-}
-
-enum LogLevel {
-  debug = 1,
-  important = 2,
-  warn = 3
-}
+import { DiagnosticsLogger, LogLevel, ServiceLogger } from './logger';
 
 const logLevelMapping = {
   'debug': LogLevel.debug,
@@ -38,113 +23,15 @@ const EVENTS_FILE_PATH = path.join(LOG_PATH, 'events.log');
 const METRICS_FILE_PATH = path.join(LOG_PATH, 'metrics.log');
 const DIAGNOSTICS_FILE_PATH = path.join(LOG_PATH, 'diagnostics.log');
 
-const REMOVE_TIMESTAMP = true;
-
 const ACCESS_LOG_FMT = 'ip=:remote-addr ts=:date[iso] method=:method path=:url http_version=:http-version req_header:req[header] status=:status content_length=:res[content-length] content_type=":res[content-type]" ref=:referrer user_agent=:user-agent elapsed_ms=:total-time[3]';
-
-/**
- * Logs to the console based on log level
- */
-export class DiagnosticsLogger {
-  public readonly logLevel: LogLevel;
-  private logger: Logger;
-  private fileLogger: RotatingFileStream;
-  private includeStackTrace: boolean;
-
-  constructor(logLevel: LogLevel) {
-    this.logger = new Logger(LoggerModes.Console, '', REMOVE_TIMESTAMP);
-    if (LOG_TO_FILES) {
-      this.fileLogger = new RotatingFileStream(DIAGNOSTICS_FILE_PATH, true);
-    }
-    this.logLevel = logLevel;
-    this.includeStackTrace = this.logLevel == LogLevel.debug ? true : false;
-  }
-
-  /**
-   * Calls `this.debug`. Used for stream interfaces.
-   * @param content Content to log
-   */
-  public write(content: string | object): void {
-    this.debug(content);
-  }
-
-  public debug(content: string | object): void {
-    if (this.logLevel > LogLevel.debug) {
-      return;
-    }
-    this.log(LogStyle.info, content);
-  }
-
-  public imp(content: string | object): void {
-    if (this.logLevel > LogLevel.important) {
-      return;
-    }
-    this.log(LogStyle.imp, content);
-  }
-
-  public warn(content: string | object): void {
-    this.log(LogStyle.warn, content);
-  }
-
-  public err(content: string | object): void {
-    this.log(LogStyle.err, content);
-  }
-
-  private log(style: LogStyle, content: string | object): void {
-    this.logger[style](content, this.includeStackTrace);
-    if (LOG_TO_FILES) {
-      const now = new Date();
-      const message = `[${now.toUTCString()}] ${content}\n`;
-      this.fileLogger.write(message);
-    }
-  }
-}
 
 interface ServiceLog {
   type: string;
   [key: string]: any;
 }
 
-/**
- * Logs content from app services to files
- */
-class ServiceLogger {
-  public service: string;
-  public filePath: string;
-  private stream: RotatingFileStream;
 
-  constructor(service: string, filePath: string) {
-    this.service = service;
-    this.filePath = filePath;
-    const writeImmediately = true;
-    this.stream = new RotatingFileStream(this.filePath, writeImmediately);
-  }
-
-  /**
-   * Converts the service log to logfmt and writes it to `this.filePath`
-   * @param serviceLog Service log object
-   * @param logToConsole True to log to console in addition to file
-   */
-  public log(serviceLog: ServiceLog, logToConsole?: boolean): void {
-    const now = new Date();
-    // RFC1123 timestamp
-    const message = `[${now.toUTCString()}] service=${this.service} ${ServiceLogger.format(serviceLog)}`;
-    this.stream.write(util.format(message, '\n'));
-    if ((LOG_LEVEL == LogLevel.debug) || logToConsole) {
-      console.log(message);
-    }
-  }
-
-  /**
-   * Converts `serviceLog` key/value object to logfmt
-   * @param serviceLog Service log object
-   */
-  public static format(serviceLog: ServiceLog): string {
-    return logfmt.stringify(serviceLog);
-  }
-}
-
-export const logger = new DiagnosticsLogger(LOG_LEVEL);
+export const logger = new DiagnosticsLogger(DIAGNOSTICS_FILE_PATH, LOG_LEVEL, LOG_TO_FILES);
 
 export const expressLoggers = buildExpressMiddleware();
 function buildExpressMiddleware() {
@@ -156,9 +43,9 @@ function buildExpressMiddleware() {
   return middleware;
 }
 
-const anchorEventsLogger = new ServiceLogger('anchor', EVENTS_FILE_PATH);
-const dbEventsLogger = new ServiceLogger('db', EVENTS_FILE_PATH);
-const ethereumEventsLogger = new ServiceLogger('ethereum', EVENTS_FILE_PATH);
+const anchorEventsLogger = new ServiceLogger('anchor', EVENTS_FILE_PATH, LOG_LEVEL);
+const dbEventsLogger = new ServiceLogger('db', EVENTS_FILE_PATH, LOG_LEVEL);
+const ethereumEventsLogger = new ServiceLogger('ethereum', EVENTS_FILE_PATH, LOG_LEVEL);
 
 export const logEvent = {
   anchor: (log: ServiceLog, logToConsole?: boolean): void => anchorEventsLogger.log(log, logToConsole),
@@ -166,8 +53,8 @@ export const logEvent = {
   ethereum: (log: ServiceLog, logToConsole?: boolean): void => ethereumEventsLogger.log(log, logToConsole)
 }
 
-const anchorMetricsLogger = new ServiceLogger('anchor', METRICS_FILE_PATH);
-const ethereumMetricsLogger = new ServiceLogger('ethereum', METRICS_FILE_PATH);
+const anchorMetricsLogger = new ServiceLogger('anchor', METRICS_FILE_PATH, LOG_LEVEL);
+const ethereumMetricsLogger = new ServiceLogger('ethereum', METRICS_FILE_PATH, LOG_LEVEL);
 
 export const logMetric = {
   anchor: (log: ServiceLog, logToConsole?: boolean): void => anchorMetricsLogger.log(log, logToConsole),

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -1,0 +1,125 @@
+import { Logger, LoggerModes } from '@overnightjs/logger';
+import * as logfmt from 'logfmt';
+import util from 'util';
+import { RotatingFileStream } from './stream-helpers';
+
+enum LogStyle {
+  info = 'info',
+  imp = 'imp',
+  warn = 'warn',
+  err = 'err'
+}
+
+export enum LogLevel {
+  debug = 1,
+  important = 2,
+  warn = 3
+}
+
+/**
+ * Logs to the console based on log level
+ */
+export class DiagnosticsLogger {
+  public readonly logLevel: LogLevel;
+  private readonly logger: Logger;
+  private readonly fileLogger: RotatingFileStream;
+  private readonly includeStackTrace: boolean;
+  private readonly logToFiles
+
+  constructor(logPath: string, logLevel: LogLevel, logToFiles: boolean) {
+    this.logLevel = logLevel;
+    this.includeStackTrace = this.logLevel == LogLevel.debug ? true : false;
+    this.logToFiles = logToFiles
+
+    const removeTimestamp = true;
+    this.logger = new Logger(LoggerModes.Console, '', removeTimestamp);
+    if (this.logToFiles) {
+      this.fileLogger = new RotatingFileStream(logPath, true);
+    }
+  }
+
+  /**
+   * Calls `this.debug`. Used for stream interfaces.
+   * @param content Content to log
+   */
+  public write(content: string | object): void {
+    this.debug(content);
+  }
+
+  public debug(content: string | object): void {
+    if (this.logLevel > LogLevel.debug) {
+      return;
+    }
+    this.log(LogStyle.info, content);
+  }
+
+  public imp(content: string | object): void {
+    if (this.logLevel > LogLevel.important) {
+      return;
+    }
+    this.log(LogStyle.imp, content);
+  }
+
+  public warn(content: string | object): void {
+    this.log(LogStyle.warn, content);
+  }
+
+  public err(content: string | object): void {
+    this.log(LogStyle.err, content);
+  }
+
+  private log(style: LogStyle, content: string | object): void {
+    this.logger[style](content, this.includeStackTrace);
+    if (this.logToFiles) {
+      const now = new Date();
+      const message = `[${now.toUTCString()}] ${content}\n`;
+      this.fileLogger.write(message);
+    }
+  }
+}
+
+interface ServiceLog {
+  type: string;
+  [key: string]: any;
+}
+
+/**
+ * Logs content from app services to files
+ */
+export class ServiceLogger {
+  public readonly service: string;
+  public readonly filePath: string;
+  private readonly stream: RotatingFileStream;
+  private readonly logLevel: LogLevel
+
+  constructor(service: string, filePath: string, logLevel: LogLevel) {
+    this.service = service;
+    this.filePath = filePath;
+    const writeImmediately = true;
+    this.stream = new RotatingFileStream(this.filePath, writeImmediately);
+    this.logLevel = logLevel
+  }
+
+  /**
+   * Converts the service log to logfmt and writes it to `this.filePath`
+   * @param serviceLog Service log object
+   * @param logToConsole True to log to console in addition to file
+   */
+  public log(serviceLog: ServiceLog, logToConsole?: boolean): void {
+    const now = new Date();
+    // RFC1123 timestamp
+    const message = `[${now.toUTCString()}] service=${this.service} ${ServiceLogger.format(serviceLog)}`;
+    this.stream.write(util.format(message, '\n'));
+    if ((this.logLevel == LogLevel.debug) || logToConsole) {
+      console.log(message);
+    }
+  }
+
+  /**
+   * Converts `serviceLog` key/value object to logfmt
+   * @param serviceLog Service log object
+   */
+  public static format(serviceLog: ServiceLog): string {
+    return logfmt.stringify(serviceLog);
+  }
+}


### PR DESCRIPTION
Splits `index.ts` into `index.ts` and `logger.ts`.  The idea is that when this moves to be its own package, the `logger.ts` will become the `index.ts` of the new `logger` package.  And then any other packages that want to use the new logger package (the cas, the rest of js-ceramic) will need something like the current `index.ts` to configure and export specific logger instances as needed for the specific package.

I guess that means that the js-ceramic monorepo will need a place to export the specific `logger` instances it needs, someplace other than the `@ceramicnetwork/logger` sub-repo.  I guess I will add a logger.ts file to the `common` package to do that.