### PR TITLE
feat: get forwarded ip in access logs

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ export default class CeramicAnchorServer extends Server {
   constructor(private container: DependencyContainer) {
     super(true);
 
+    this.app.set('trust proxy', true);
     this.app.use(bodyParser.json());
     this.app.use(bodyParser.urlencoded({ extended: true }));
     this.app.use(...expressLoggers)


### PR DESCRIPTION
Related to #295 and allows us to see requests per origin properly in metrics