### PR TITLE
feat(breaking): change access log to http-access

### DIFF
--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -12,7 +12,7 @@ if (!LOG_PATH.endsWith('/')) {
   LOG_PATH = LOG_PATH + '/';
 }
 
-const ACCESS_FILE_PATH = path.join(LOG_PATH, 'access.log');
+const ACCESS_FILE_PATH = path.join(LOG_PATH, 'http-access.log');
 const EVENTS_FILE_PATH = path.join(LOG_PATH, 'events.log');
 const METRICS_FILE_PATH = path.join(LOG_PATH, 'metrics.log');
 const DIAGNOSTICS_FILE_PATH = path.join(LOG_PATH, 'diagnostics.log');
@@ -39,12 +39,8 @@ function buildExpressMiddleware() {
     return req.path;
   });
 
-  const middleware = [morgan('combined', { stream: logger })];
-
-  if (LOG_TO_FILES) {
-    const accessLogStream = new RotatingFileStream(ACCESS_FILE_PATH, true);
-    middleware.push(morgan(ACCESS_LOG_FMT, { stream: accessLogStream }));
-  }
+  const logger = new ServiceLogger('http-access', ACCESS_FILE_PATH, LOG_LEVEL, LOG_TO_FILES);
+  const middleware = [morgan(ACCESS_LOG_FMT, { stream: logger })];
 
   return middleware;
 }


### PR DESCRIPTION
### Motivation

Access logs should match formatting of other logs. Also want the file name to match what we have in js-ceramic.

### Changes

- Change file name to 'http-access.log'
- Use service logger for morgan middleware (as we do in js-ceramic)

### Notes

Related to metrics dashboard updates for the file name https://github.com/3box/ceramic-stats/commit/b4d1462fadad40e8a2e5445cde55dc72b0bb9726