### PR TITLE
fix(cas): Add timeout to how long we wait for eth transactions to get mined

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -26,6 +26,7 @@
           "port": "8545",
           "url": ""
         },
+        "transactionTimeoutSecs": 60,
         "account": {
           "privateKey": "0x06dd0990d19001c57eeea6d32e8fdeee40d3945962caf18c18c3930baa5a6ec9"
         }

--- a/config/env/dev.json
+++ b/config/env/dev.json
@@ -26,6 +26,7 @@
           "port": "@@ETH_RPC_PORT",
           "url": "@@ETH_RPC_URL"
         },
+        "tranactionTimeoutSecs": "@@ETH_TXN_TIMEOUT",
         "account": {
           "privateKey": "@@ETH_WALLET_PK"
         }

--- a/config/env/prod.json
+++ b/config/env/prod.json
@@ -26,6 +26,7 @@
           "port": "@@ETH_RPC_PORT",
           "url": "@@ETH_RPC_URL"
         },
+        "tranactionTimeoutSecs": "@@ETH_TXN_TIMEOUT",
         "account": {
           "privateKey": "@@ETH_WALLET_PK"
         }

--- a/config/env/test.json
+++ b/config/env/test.json
@@ -16,6 +16,7 @@
           "host": "http://localhost",
           "port": "6000"
         },
+        "tranactionTimeoutSecs": 600,
         "account": {
           "privateKey": "0x06dd0990d19001c57eeea6d32e8fdeee40d3945962caf18c18c3930baa5a6ec9"
         }

--- a/src/services/blockchain/__tests__/__snapshots__/eth-bc-service.test.ts.snap
+++ b/src/services/blockchain/__tests__/__snapshots__/eth-bc-service.test.ts.snap
@@ -3,7 +3,6 @@
 exports[`ETH service should send CID to local ganache server 1`] = `
 Transaction {
   "blockNumber": 1,
-  "blockTimestamp": 1586784004,
   "chain": "eip155:1337",
   "txHash": "0x873417e4596dbf4f2c262986f0bf4431e7a0c6aa9b9639496dc5de81423d206f",
 }

--- a/src/services/blockchain/__tests__/eth-bc-service.test.ts
+++ b/src/services/blockchain/__tests__/eth-bc-service.test.ts
@@ -16,6 +16,7 @@ let ethBc: BlockchainService = null;
 
 describe('ETH service',  () => {
   jest.setTimeout(25000);
+  const blockchainStartTime = new Date(1586784002000)
   beforeAll(async () => {
     container.register("blockchainService", {
       useClass: EthereumBlockchainService
@@ -25,7 +26,7 @@ describe('ETH service',  () => {
 
     ganacheServer = Ganache.server({
       gasLimit: 7000000,
-      time: new Date(1586784002855),
+      time: blockchainStartTime,
       mnemonic: 'move sense much taxi wave hurry recall stairs thank brother nut woman',
       default_balance_ether: 100,
       debug: true,
@@ -55,6 +56,15 @@ describe('ETH service',  () => {
     const cid = new CID('bafyreic5p7grucmzx363ayxgoywb6d4qf5zjxgbqjixpkokbf5jtmdj5ni');
     const tx = await ethBc.sendTransaction(cid);
     expect(tx).toBeDefined();
+
+    // checking the timestamp against the snapshot is too brittle since if the test runs slowly it
+    // can be off slightly.  So we test it manually here instead.
+    const blockTimestamp = tx.blockTimestamp
+    delete tx.blockTimestamp
+    const startTimeSeconds = blockchainStartTime.getTime() / 1000
+    expect(blockTimestamp).toBeGreaterThan(startTimeSeconds)
+    expect(blockTimestamp).toBeLessThan(startTimeSeconds + 5)
+
     expect(tx).toMatchSnapshot();
   });
 

--- a/src/services/blockchain/__tests__/eth-bc-service.test.ts
+++ b/src/services/blockchain/__tests__/eth-bc-service.test.ts
@@ -61,7 +61,7 @@ describe('ETH service',  () => {
     // can be off slightly.  So we test it manually here instead.
     const blockTimestamp = tx.blockTimestamp
     delete tx.blockTimestamp
-    const startTimeSeconds = blockchainStartTime.getTime() / 1000
+    const startTimeSeconds = Math.floor(blockchainStartTime.getTime() / 1000)
     expect(blockTimestamp).toBeGreaterThan(startTimeSeconds)
     expect(blockTimestamp).toBeLessThan(startTimeSeconds + 5)
 

--- a/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
+++ b/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
@@ -10,6 +10,7 @@ import { logger, logEvent, logMetric } from "../../../logger";
 import Transaction from "../../../models/transaction";
 import BlockchainService from "../blockchain-service";
 import { TransactionRequest } from "@ethersproject/abstract-provider";
+import Utils from '../../../utils';
 
 const BASE_CHAIN_ID = "eip155";
 const TX_FAILURE = 0;
@@ -202,7 +203,7 @@ export default class EthereumBlockchainService implements BlockchainService {
           throw new Error("Failed to send transaction");
         } else {
           logger.warn(`Failed to send transaction; ${MAX_RETRIES - attemptNum} retries remain`)
-          await new Promise(resolve => setTimeout(resolve, 5000));
+          await Utils.delay(5000)
         }
       }
     }

--- a/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
+++ b/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
@@ -14,6 +14,7 @@ import { TransactionRequest } from "@ethersproject/abstract-provider";
 const BASE_CHAIN_ID = "eip155";
 const TX_FAILURE = 0;
 const TX_SUCCESS = 1;
+const MAX_RETRIES = 3;
 
 const POLLING_INTERVAL = 15 * 1000 // every 15 seconds
 
@@ -57,6 +58,34 @@ export default class EthereumBlockchainService implements BlockchainService {
   }
 
   /**
+   * Sets the gas price for the transaction request
+   * @param txData - transaction request data
+   * @param attempt - what number attempt this is at submitting the transaction.  We increase
+   *   the gas price we set by a 10% multiple with each subsequent attempt
+   * @private
+   */
+  private async _setGasPrice(txData: TransactionRequest, attempt: number): Promise<void> {
+    const { overrideGasConfig } = config.blockchain.connectors.ethereum;
+    if (config.blockchain.connectors.ethereum.overrideGasConfig) {
+      txData.gasPrice = BigNumber.from(config.blockchain.connectors.ethereum.gasPrice);
+      logger.debug('Overriding Gas price: ' + txData.gasPrice.toString());
+
+      txData.gasLimit = BigNumber.from(config.blockchain.connectors.ethereum.gasLimit);
+      logger.debug('Overriding Gas limit: ' + txData.gasLimit.toString());
+    } else {
+      const gasPriceEstimate = await this.provider.getGasPrice();
+      // Add 10% extra to gas price for each subsequent attempt
+      txData.gasPrice = gasPriceEstimate.add(gasPriceEstimate.mul(attempt * .01));
+      logger.debug('Estimated Gas price: ' + txData.gasPrice.toString());
+
+      txData.gasLimit = await this.provider.estimateGas(txData);
+      logger.debug('Estimated Gas limit: ' + txData.gasLimit.toString());
+    }
+
+
+  }
+
+  /**
    * Returns the cached 'chainId' representing the CAIP-2 ID of the configured blockchain.
    * Invalid to call before calling connect()
    */
@@ -91,26 +120,10 @@ export default class EthereumBlockchainService implements BlockchainService {
       nonce: baseNonce,
     };
 
-    const { overrideGasConfig } = config.blockchain.connectors.ethereum;
-    if (config.blockchain.connectors.ethereum.overrideGasConfig) {
-      txData.gasPrice = BigNumber.from(config.blockchain.connectors.ethereum.gasPrice);
-      logger.debug('Overriding Gas price: ' + txData.gasPrice.toString());
-
-      txData.gasLimit = BigNumber.from(config.blockchain.connectors.ethereum.gasLimit);
-      logger.debug('Overriding Gas limit: ' + txData.gasLimit.toString());
-    }
-
-    let retryTimes = 3;
-    while (retryTimes > 0) {
+    let attemptNum = 0;
+    while (attemptNum < MAX_RETRIES) {
       try {
-        if (!overrideGasConfig) {
-          txData.gasPrice = await this.provider.getGasPrice();
-          logger.debug('Estimated Gas price: ' + txData.gasPrice.toString());
-
-          txData.gasLimit = await this.provider.estimateGas(txData);
-          logger.debug('Estimated Gas limit: ' + txData.gasLimit.toString());
-        }
-
+        await this._setGasPrice(txData, attemptNum);
         logger.imp("Transaction data:" + JSON.stringify(txData));
 
         logEvent.ethereum({
@@ -176,11 +189,11 @@ export default class EthereumBlockchainService implements BlockchainService {
           }
         }
 
-        retryTimes--;
-        if (retryTimes === 0) {
+        attemptNum++;
+        if (attemptNum >= MAX_RETRIES) {
           throw new Error("Failed to send transaction");
         } else {
-          logger.warn(`Failed to send transaction; ${retryTimes} retries remain`)
+          logger.warn(`Failed to send transaction; ${MAX_RETRIES - attemptNum} retries remain`)
           await new Promise(resolve => setTimeout(resolve, 5000));
         }
       }

--- a/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
+++ b/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
@@ -15,6 +15,9 @@ const BASE_CHAIN_ID = "eip155";
 const TX_FAILURE = 0;
 const TX_SUCCESS = 1;
 
+const POLLING_INTERVAL = 15 * 1000 // every 15 seconds
+const TRANSACTION_TIMEOUT = 60 * 60 * 1000 // 1 hour
+
 /**
  * Ethereum blockchain service
  */
@@ -37,6 +40,8 @@ export default class EthereumBlockchainService implements BlockchainService {
     } else {
       this.provider = ethers.getDefaultProvider(network);
     }
+
+    this.provider.pollingInterval = POLLING_INTERVAL
 
     await this.provider.getNetwork();
     await this._loadChainId();
@@ -131,7 +136,7 @@ export default class EthereumBlockchainService implements BlockchainService {
           throw new Error("Chain ID of connected blockchain changed from " + this.chainId + " to " + caip2ChainId)
         }
 
-        const txReceipt: providers.TransactionReceipt = await this.provider.waitForTransaction(txResponse.hash);
+        const txReceipt: providers.TransactionReceipt = await this.provider.waitForTransaction(txResponse.hash, 1, TRANSACTION_TIMEOUT);
         logEvent.ethereum({
           type: 'txReceipt',
           ...txReceipt

--- a/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
+++ b/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
@@ -16,7 +16,6 @@ const TX_FAILURE = 0;
 const TX_SUCCESS = 1;
 
 const POLLING_INTERVAL = 15 * 1000 // every 15 seconds
-const TRANSACTION_TIMEOUT = 60 * 60 * 1000 // 1 hour
 
 /**
  * Ethereum blockchain service
@@ -136,7 +135,8 @@ export default class EthereumBlockchainService implements BlockchainService {
           throw new Error("Chain ID of connected blockchain changed from " + this.chainId + " to " + caip2ChainId)
         }
 
-        const txReceipt: providers.TransactionReceipt = await this.provider.waitForTransaction(txResponse.hash, 1, TRANSACTION_TIMEOUT);
+        const txReceipt: providers.TransactionReceipt = await this.provider.waitForTransaction(
+          txResponse.hash, 1, config.blockchain.connectors.ethereum.transactionTimeoutSecs * 1000);
         logEvent.ethereum({
           type: 'txReceipt',
           ...txReceipt

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,6 +22,14 @@ export default class Utils {
   }
 
   /**
+   * "sleeps" for the given number of milliseconds
+   * @param mills
+   */
+  static async delay(mills: number): Promise<void> {
+    await new Promise<void>(resolve => setTimeout(() => resolve(), mills))
+  }
+
+  /**
    * Converts ETH address to CID
    * @param codec - ETH coded
    * @param hash - ETH hash


### PR DESCRIPTION
This change increases the rate at which the ethers library will poll infura from every 4 seconds to every 15 seconds (just over the block production rate), and adds a 1 hour timeout to how long we wait for each submitted transaction to be mined.

There is one failure mode I'd like help thinking through whether or not this is a security concern and if there's anything we can do to mitigate it.  What if we submit a transaction that doesn't get mined (let's say because gas price is too low).  We time it out after an hour and retry up to 3 times (recalculating gas price each time).  But after the final retry times out, we declare the transaction failed and move on.  The anchor batch is declared a failure, and the pending CIDs to be anchored stick around in the database and get picked up in the next anchor batch (which we'll assume is successful).

What if, after we give up on the transaction after an hour (and with 3 retries), the transaction actually *does* wind up eventually getting mined (say, because gas prices come down).  Now the CIDs were anchored twice, but only the second time they were anchored generated an anchor proof and corresponding ceramic anchor commits.  Now a bunch of time passes and new updates are made on top of some of the documents that were updated.  What if someone inspects the blockchain and realizes that there was an anchor batch that made it on chain, but never had AnchorCommits published for them?  They could then go and publish AnchorCommits from this batch that actually succeeded but we gave up on, and in so doing revert the history on a bunch of documents from that batch.

The problem is, I'm not sure there's anything we can actually do to prevent this with our current anchoring model.  We could wait longer before giving up on a transaction, but there's never a time after which we can be 100% certain it won't be mined in the future.  Am I missing something @oed?