### PR TITLE
fix(cas): Fix underflow error in gas price math

### DIFF
--- a/src/services/blockchain/__tests__/eth-bc-service.test.ts
+++ b/src/services/blockchain/__tests__/eth-bc-service.test.ts
@@ -82,9 +82,9 @@ describe('ETH service',  () => {
 
   test('gas price increase math', () => {
     const currentGas = BigNumber.from(1000)
-    expect(EthereumBlockchainService.increaseGasPrice(currentGas, 0)).toEqual(currentGas)
-    expect(EthereumBlockchainService.increaseGasPrice(currentGas, 1)).toEqual(BigNumber.from(1100))
-    expect(EthereumBlockchainService.increaseGasPrice(currentGas, 2)).toEqual(BigNumber.from(1200))
+    expect(EthereumBlockchainService.increaseGasPricePerAttempt(currentGas, 0)).toEqual(currentGas)
+    expect(EthereumBlockchainService.increaseGasPricePerAttempt(currentGas, 1)).toEqual(BigNumber.from(1100))
+    expect(EthereumBlockchainService.increaseGasPricePerAttempt(currentGas, 2)).toEqual(BigNumber.from(1200))
   })
 
 });

--- a/src/services/blockchain/__tests__/eth-bc-service.test.ts
+++ b/src/services/blockchain/__tests__/eth-bc-service.test.ts
@@ -10,6 +10,7 @@ import { container } from "tsyringe";
 
 import BlockchainService from "../blockchain-service";
 import EthereumBlockchainService from "../ethereum/ethereum-blockchain-service";
+import { BigNumber } from 'ethers';
 
 let ganacheServer: any = null;
 let ethBc: BlockchainService = null;
@@ -48,6 +49,12 @@ describe('ETH service',  () => {
     await done
   });
 
+  afterAll(async (done) => {
+    logger.imp(`Closing local Ethereum blockchain instance...`);
+    ganacheServer.close();
+    done();
+  });
+
   test('should connect to local ganache server', async () => {
     await ethBc.connect();
   });
@@ -73,10 +80,11 @@ describe('ETH service',  () => {
     expect(chainId).toEqual("eip155:1337")
   });
 
-  afterAll(async (done) => {
-    logger.imp(`Closing local Ethereum blockchain instance...`);
-    ganacheServer.close();
-    done();
-  });
+  test('gas price increase math', () => {
+    const currentGas = BigNumber.from(1000)
+    expect(EthereumBlockchainService.increaseGasPrice(currentGas, 0)).toEqual(currentGas)
+    expect(EthereumBlockchainService.increaseGasPrice(currentGas, 1)).toEqual(BigNumber.from(1100))
+    expect(EthereumBlockchainService.increaseGasPrice(currentGas, 2)).toEqual(BigNumber.from(1200))
+  })
 
 });

--- a/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
+++ b/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
@@ -76,7 +76,7 @@ export default class EthereumBlockchainService implements BlockchainService {
     } else {
       const gasPriceEstimate = await this.provider.getGasPrice();
       // Add 10% extra to gas price for each subsequent attempt
-      txData.gasPrice = EthereumBlockchainService.increaseGasPrice(gasPriceEstimate, attempt)
+      txData.gasPrice = EthereumBlockchainService.increaseGasPricePerAttempt(gasPriceEstimate, attempt)
       logger.debug('Estimated Gas price: ' + txData.gasPrice.toString());
 
       txData.gasLimit = await this.provider.estimateGas(txData);
@@ -89,7 +89,7 @@ export default class EthereumBlockchainService implements BlockchainService {
    * @param currentGas
    * @param attempt
    */
-  static increaseGasPrice(currentGas: BigNumber, attempt: number): BigNumber {
+  static increaseGasPricePerAttempt(currentGas: BigNumber, attempt: number): BigNumber {
     const tenPercent = currentGas.div(10)
     const additionalGas = tenPercent.mul(attempt)
     return currentGas.add(additionalGas)

--- a/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
+++ b/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
@@ -74,10 +74,10 @@ export default class EthereumBlockchainService implements BlockchainService {
       txData.gasLimit = BigNumber.from(config.blockchain.connectors.ethereum.gasLimit);
       logger.debug('Overriding Gas limit: ' + txData.gasLimit.toString());
     } else {
-      const gasPriceEstimate = await this.provider.getGasPrice();
-      // Add 10% extra to gas price for each subsequent attempt
+      const gasPriceEstimate = await this.provider.getGasPrice(); // in wei
+      // Add extra to gas price for each subsequent attempt
       txData.gasPrice = EthereumBlockchainService.increaseGasPricePerAttempt(gasPriceEstimate, attempt)
-      logger.debug('Estimated Gas price: ' + txData.gasPrice.toString());
+      logger.debug('Estimated Gas price (in wei): ' + txData.gasPrice.toString());
 
       txData.gasLimit = await this.provider.estimateGas(txData);
       logger.debug('Estimated Gas limit: ' + txData.gasLimit.toString());

--- a/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
+++ b/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
@@ -65,7 +65,7 @@ export default class EthereumBlockchainService implements BlockchainService {
    *   the gas price we set by a 10% multiple with each subsequent attempt
    * @private
    */
-  private async _setGasPrice(txData: TransactionRequest, attempt: number): Promise<void> {
+  async setGasPrice(txData: TransactionRequest, attempt: number): Promise<void> {
     const { overrideGasConfig } = config.blockchain.connectors.ethereum;
     if (config.blockchain.connectors.ethereum.overrideGasConfig) {
       txData.gasPrice = BigNumber.from(config.blockchain.connectors.ethereum.gasPrice);
@@ -76,14 +76,23 @@ export default class EthereumBlockchainService implements BlockchainService {
     } else {
       const gasPriceEstimate = await this.provider.getGasPrice();
       // Add 10% extra to gas price for each subsequent attempt
-      txData.gasPrice = gasPriceEstimate.add(gasPriceEstimate.mul(attempt * .01));
+      txData.gasPrice = EthereumBlockchainService.increaseGasPrice(gasPriceEstimate, attempt)
       logger.debug('Estimated Gas price: ' + txData.gasPrice.toString());
 
       txData.gasLimit = await this.provider.estimateGas(txData);
       logger.debug('Estimated Gas limit: ' + txData.gasLimit.toString());
     }
+  }
 
-
+  /**
+   * Takes current gas price and attempt number and returns new gas price with 10% increase per attempt
+   * @param currentGas
+   * @param attempt
+   */
+  static increaseGasPrice(currentGas: BigNumber, attempt: number): BigNumber {
+    const divider = BigNumber.from(attempt).mul(10)
+    const additionalGas = currentGas.div(divider)
+    return currentGas.add(additionalGas)
   }
 
   /**
@@ -125,7 +134,7 @@ export default class EthereumBlockchainService implements BlockchainService {
     let attemptNum = 0;
     while (attemptNum < MAX_RETRIES) {
       try {
-        await this._setGasPrice(txData, attemptNum);
+        await this.setGasPrice(txData, attemptNum);
         logger.imp("Transaction data:" + JSON.stringify(txData));
 
         logEvent.ethereum({

--- a/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
+++ b/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
@@ -90,8 +90,8 @@ export default class EthereumBlockchainService implements BlockchainService {
    * @param attempt
    */
   static increaseGasPrice(currentGas: BigNumber, attempt: number): BigNumber {
-    const divider = BigNumber.from(attempt).mul(10)
-    const additionalGas = currentGas.div(divider)
+    const tenPercent = currentGas.div(10)
+    const additionalGas = tenPercent.mul(attempt)
     return currentGas.add(additionalGas)
   }
 


### PR DESCRIPTION
ether's `BigNumber` package doesn't like decimals, so this changes the math from multiplying by .01 to dividing by 10