### PR TITLE
fix(ci): build docker image on main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,9 @@ workflows:
           extra-build-args: --build-arg CODE_VERSION=${CIRCLE_SHA1:0:7}
           filters:
             branches:
-              only: develop
+              only:
+               - main
+               - develop
 #       - deploy-dev:
 #           requires:
 #             - push-dev-image


### PR DESCRIPTION
This is needed because CAS clay is still using the ECR image tagged develop. So this builds the ECR image for it to use when changes are merged into `main` so that the clay instances get the new image.

This code will be removed once we clean up the pipelines here.