### PR TITLE
Hotfix: Exit anchor mode

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -167,7 +167,7 @@ export default class CeramicAnchorApp {
    * Execute a single anchor process
    */
   private async _executeAnchor(): Promise<void> {
-    await this.startWithConnectionHandling(async () => {
+    this.startWithConnectionHandling(async () => {
       const anchorService: AnchorService = container.resolve<AnchorService>('anchorService');
       await anchorService.anchorRequests();
     });

--- a/src/app.ts
+++ b/src/app.ts
@@ -141,7 +141,10 @@ export default class CeramicAnchorApp {
     const ipfsService: IpfsServiceImpl = container.resolve<IpfsServiceImpl>('ipfsService');
     await ipfsService.init();
 
-    await this._executeAnchor();
+    this.startWithConnectionHandling(async () => {
+      const anchorService: AnchorService = container.resolve<AnchorService>('anchorService');
+      await anchorService.anchorRequests();
+    });
   }
 
   /**
@@ -161,16 +164,6 @@ export default class CeramicAnchorApp {
       process.exit(1);
     }
     await fn();
-  }
-
-  /**
-   * Execute a single anchor process
-   */
-  private async _executeAnchor(): Promise<void> {
-    this.startWithConnectionHandling(async () => {
-      const anchorService: AnchorService = container.resolve<AnchorService>('anchorService');
-      await anchorService.anchorRequests();
-    });
   }
 }
 

--- a/src/services/ceramic-service.ts
+++ b/src/services/ceramic-service.ts
@@ -31,12 +31,13 @@ export default class CeramicServiceImpl implements CeramicService {
 
     const docPromise = this._client.loadDocument(docId, {sync: false})
       .then((data) => {
-        clearTimeout(timeout);
         return data;
       })
       .catch((err) => {
-        clearTimeout(timeout);
         throw Error(err);
+      })
+      .finally(() => {
+        clearTimeout(timeout);
       });
 
     const timeoutPromise = new Promise((_, reject) => {

--- a/src/services/ceramic-service.ts
+++ b/src/services/ceramic-service.ts
@@ -1,4 +1,4 @@
-import { Resolver } from "did-resolver"
+import { Resolver } from "did-resolver";
 
 import CeramicClient from '@ceramicnetwork/http-client';
 import { CeramicApi, Doctype } from '@ceramicnetwork/common';
@@ -27,8 +27,24 @@ export default class CeramicServiceImpl implements CeramicService {
   }
 
   async loadDocument<T extends Doctype>(docId: DocID): Promise<T> {
+    let timeout: NodeJS.Timeout;
+
     const docPromise = this._client.loadDocument(docId, {sync: false})
-    const timeoutPromise = new Promise((_, reject) => setTimeout(() => reject(`Timed out loading docid: ${docId.toString()}`), 60 * 1000))
+      .then((data) => {
+        clearTimeout(timeout);
+        return data;
+      })
+      .catch((err) => {
+        clearTimeout(timeout);
+        throw Error(err);
+      });
+
+    const timeoutPromise = new Promise((_, reject) => {
+      timeout = setTimeout(() => {
+        reject(`Timed out loading docid: ${docId.toString()}`)
+      }, 60 * 1000);
+    });
+
     return (await Promise.race([docPromise, timeoutPromise])) as T
   }
 }

--- a/src/services/ceramic-service.ts
+++ b/src/services/ceramic-service.ts
@@ -30,12 +30,6 @@ export default class CeramicServiceImpl implements CeramicService {
     let timeout: NodeJS.Timeout;
 
     const docPromise = this._client.loadDocument(docId, {sync: false})
-      .then((data) => {
-        return data;
-      })
-      .catch((err) => {
-        throw Error(err);
-      })
       .finally(() => {
         clearTimeout(timeout);
       });


### PR DESCRIPTION
### Motivation

Clay CAS instances are hanging on our infra (AWS ECS) even though it seems like all the node processes should have exited. Testing locally if loading a doc fails execution would continue but the process would not exit until after the timeout of 60s. However, on our infra it seems that the introduction of this timeout keeps the process running indefinitely.

I believe this change helps the issue by clearing the timeout (because we aren't seeing this issue on dev), but I can't be sure until we run it on ECS. If it still hangs it is likely we need to make an explicit call to `process.exit()` after anchoring.

### Changes

- Clears `setTimeout` if `loadDocument` resolves or rejects
- Cleans up the execute anchor code to be a bit neater
  - *We are seeing out of order log messages because the anchor service module was being awaited when it should be run non-blocking*

