### PR TITLE
feat(ci): add workflow to build and push ecr image

### DIFF
--- a/.github/workflows/build_and_push_ecr.yml
+++ b/.github/workflows/build_and_push_ecr.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+      - develop
       - feat/check-running-anchor-process # will remove after testing
   workflow_dispatch:
 

--- a/.github/workflows/build_and_push_ecr.yml
+++ b/.github/workflows/build_and_push_ecr.yml
@@ -1,0 +1,50 @@
+on:
+  push:
+    branches:
+      - main
+      - feat/check-running-anchor-process # will remove after testing
+  workflow_dispatch:
+
+name: Build and Push to ECR
+
+jobs:
+  run:
+    name: Build and Push to ECR
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      
+    - name: Set Variables
+      id: vars
+      run: |
+        if [[ "${{github.base_ref}}" == "main" || "${{github.ref}}" == "refs/heads/main" ]]; then
+          echo "::set-output name=ECR_REPOSITORY::ceramic-tnet-cas"
+          echo "::set-output name=IMAGE_TAG::latest"
+        else
+          echo "::set-output name=ECR_REPOSITORY::ceramic-dev-cas"
+          echo "::set-output name=IMAGE_TAG::dev"
+        fi
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-2
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: ${{ steps.set-vars.outputs.ECR_REPOSITORY }}
+        SHA_TAG: ${{ github.sha }}
+      run: |
+        docker build -f Dockerfile -t cas .
+        docker build -f Dockerfile.runner -t $ECR_REGISTRY/$ECR_REPOSITORY:$SHA_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.set-vars.outputs.IMAGE_TAG }} .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY --all-tags


### PR DESCRIPTION
### Motivation

1. We are moving away from using CircleCI so this will replace the existing workflow that we have configured there
2. We want to build a new docker image for CAS that uses the "CAS runner" (see: #338)

### Changes

- Adds github workflow that builds image on push or when manually triggered

### Notes

- Have a feature branch in the workflow so we can test this without needing to merge to develop each time, but this needs to be merged in first on develop in order for the action to be available for testing on other branches. (Just how github actions works).