### PR TITLE
fix: run anchor mode if only 1 task is running

### DIFF
--- a/runner/check-aws-ecs-tasks.js
+++ b/runner/check-aws-ecs-tasks.js
@@ -22,11 +22,11 @@ async function main() {
   if (data.$metadata.httpStatusCode > 399) {
     throw Error(data.$metadata.httpStatusCode)
   } else {
-    if (data.taskArns.length > 0) {
-      console.log('Tasks already running')
+    if (data.taskArns.length > 1) {
+      console.log('More than one task already running')
       console.log(data.taskArns)
     } else {
-      console.log('No running tasks found')
+      console.log('Only one running task found')
     }
   }
 }

--- a/runner/check-aws-ecs-tasks.js
+++ b/runner/check-aws-ecs-tasks.js
@@ -26,7 +26,7 @@ async function main() {
       console.log('More than one task already running')
       console.log(data.taskArns)
     } else {
-      console.log('Only one running task found')
+      console.log('Only one running task found (assumed to be self)')
     }
   }
 }
@@ -39,4 +39,3 @@ main()
     console.error(error)
     process.exit(1)
   })
-


### PR DESCRIPTION
When we detect if a task is running it is seeing itself running then exiting. So we need to check if any *additional* tasks are running.