### PR TITLE
feat: send discord notif if anchor hangs

### DIFF
--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -10,6 +10,9 @@ ENV AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
 ENV AWS_ECS_CLUSTER=${AWS_ECS_CLUSTER}
 ENV AWS_ECS_FAMILY=${AWS_ECS_FAMILY}
 
+# Discord notifications about running ECS tasks
+ENV DISCORD_WEBHOOK_URL=${DISCORD_WEBHOOK_URL}
+
 WORKDIR /runner
 
 COPY runner/package*.json runner/*.js ./

--- a/runner/check-aws-ecs-tasks.js
+++ b/runner/check-aws-ecs-tasks.js
@@ -1,3 +1,4 @@
+const https = require('https')
 const { ECSClient, ListTasksCommand } = require('@aws-sdk/client-ecs')
 
 async function main() {
@@ -26,11 +27,50 @@ async function main() {
       console.log('HALT')
       console.log('More than one task already running')
       console.log(data.taskArns)
+      const retryDelayMs = 300000 // 300k ms = 5 mins
+      sendNotification(data.taskArns, retryDelayMs)
     } else {
       console.log('OK')
       console.log('Only one running task found (assumed to be self)')
     }
   }
+}
+
+function sendNotification(taskArns, retryDelayMs = -1) {
+  const url = process.env.DISCORD_WEBHOOK_URL
+  const options = {
+    method: 'POST',
+    headers: {
+      "Content-Type": "application/json"
+    }
+  }
+  const message = [
+    {
+      title: 'CAS still running',
+      description: `A new CAS anchor task was not started because there is already at least one running.`,
+      color: 16776960,
+      fields: [
+        {
+          name: 'ARNs for Running CAS Anchor Tasks',
+          value: `${JSON.stringify(data.taskArns)}`,
+        }
+      ],
+    },
+  ]
+  const data = { embeds: message, username: 'cas-runner' }
+
+  const req = https.request(url, options, (res) => {
+    console.log(`Notification request status code: ${res.statusCode}`)
+    if (res.statusCode >= 500 && retryDelayMs > -1) {
+      console.log(`Retrying after ${retryDelayMs} milliseconds...`)
+      setTimeout(() => {
+        sendNotification(taskArns)
+      }, retryDelayMs)
+    }
+  })
+  req.on('error', console.error)
+  req.write(JSON.stringify(data))
+  req.end()
 }
 
 main()

--- a/runner/check-aws-ecs-tasks.js
+++ b/runner/check-aws-ecs-tasks.js
@@ -44,17 +44,21 @@ function sendNotification(taskArns, retryDelayMs = -1) {
       "Content-Type": "application/json"
     }
   }
+  const arnRegex = /\w+$/
+  const fields = data.taskArns.map((arn, index) => {
+    let value = arn
+    const id = arn.match(arnRegex)
+    if (id) {
+      value = `${process.env.CLOUDWATCH_LOG_PATH}/${id[0]}`
+    }
+    return { name: `Task ${index}`, value }
+  })
   const message = [
     {
       title: 'CAS still running',
       description: `A new CAS anchor task was not started because there is already at least one running.`,
       color: 16776960,
-      fields: [
-        {
-          name: 'ARNs for Running CAS Anchor Tasks',
-          value: `${JSON.stringify(data.taskArns)}`,
-        }
-      ],
+      fields,
     },
   ]
   const data = { embeds: message, username: 'cas-runner' }

--- a/runner/check-aws-ecs-tasks.js
+++ b/runner/check-aws-ecs-tasks.js
@@ -49,7 +49,7 @@ function sendNotification(taskArns, retryDelayMs = -1) {
     let value = arn
     const id = arn.match(arnRegex)
     if (id) {
-      value = `${process.env.CLOUDWATCH_LOG_PATH}/${id[0]}`
+      value = `${process.env.CLOUDWATCH_LOG_BASE_URL}/${id[0]}`
     }
     return { name: `Task ${index}`, value }
   })


### PR DESCRIPTION
Current behavior:

If an anchor task spins up when at least one task is already running, the task exits without anchoring.

New behavior:

Before exiting a discord message will be sent to the alerts channel indicating that the latest anchor task has not completed by the time the next one is scheduled to start.

### Notes

- Relies on infra update to add discord webhook url env var https://github.com/3box/ceramic-infra/commit/40d12cdc8aff8315dc9a9e786fb6eaab3c72a99b