### PR TITLE
fix(cas): Load candidate streams in parallel batches

### DIFF
--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -241,9 +241,9 @@ export default class AnchorService {
    */
   async _findCandidates(requests: Request[]): Promise<Candidate[]> {
     logger.debug(`About to load candidate documents`)
-    const groupedCandidates = await this._groupCandidatesByDocId(requests)
+    const candidates = await this._loadCandidateStreams(requests)
     logger.debug(`Successfully loaded candidate documents, about to apply conflict resolution to conflicting requests`)
-    const [selectedCandidates, conflictingCandidates] = await this._selectValidCandidates(groupedCandidates)
+    const [selectedCandidates, conflictingCandidates] = await this._selectValidCandidates(candidates)
     logger.debug(`About to fail requests rejected by conflict resolution`)
     await this._failConflictingRequests(requests, conflictingCandidates)
 
@@ -251,14 +251,14 @@ export default class AnchorService {
   }
 
   /**
-   * Takes an array of Requests, and returns Candidate objects grouped by Ceramic DocId. Documents
-   * that couldn't be loaded successfully will be filtered out from the result set
+   * Takes an array of Requests, and returns Candidate objects for each Document that could be
+   * loaded successfully. Documents that couldn't be loaded successfully will be filtered out from
+   * the result set. Also limits the size of the output set of Candidates based on the configured
+   * merkleDepthLimit
    * @param requests - array of anchor requests
-   * @returns - map of docIds to 'Candidate' objects.
+   * @returns - Array of 'Candidate' objects.
    */
-  async _groupCandidatesByDocId(requests: Request[]): Promise<Map<string, Candidate[]>> {
-    const groupedCandidates: Map<string, Candidate[]> = new Map();
-
+  async _loadCandidateStreams(requests: Request[]): Promise<Candidate[]> {
     let streamLimit = -1
     if (config.merkleDepthLimit > 0) {
       // The number of streams we are able to include in a single anchor batch is limited by the
@@ -266,10 +266,10 @@ export default class AnchorService {
       streamLimit = Math.pow(2, config.merkleDepthLimit)
     }
 
-    let request = null;
+    const candidates = []
     for (let index = 0; index < requests.length; index++) {
-      if (streamLimit > 0 && groupedCandidates.size >= streamLimit) {
-        logger.warn('More than ' + groupedCandidates.size + ' candidate streams found, ' +
+      if (streamLimit > 0 && candidates.length >= streamLimit) {
+        logger.warn('More than ' + candidates.length + ' candidate streams found, ' +
           'which is the limit that can fit in a merkle tree of depth ' + config.merkleDepthLimit +
           '. Returning unprocessed requests to PENDING status')
 
@@ -278,41 +278,66 @@ export default class AnchorService {
           status: RS.PENDING,
           message: "Request returned to pending.",
         }, unprocessedRequests);
-        return groupedCandidates
+        return candidates
       }
 
-      let docId
-      try {
-        request = requests[index];
+      const request = requests[index];
+      const candidate = await this._loadCandidateForRequest(request)
+      if (candidate) {
+        candidates.push(candidate)
+      }
+    }
+    return candidates
+  }
 
-        docId = this._getRequestDocID(request)
-        const doc = await this.ceramicService.loadDocument(docId)
-        if (!doc) {
-          throw new Error(`No valid ceramic document found with docId ${docId.toString()}`)
-        }
+  /**
+   * Takes a list of candidates and groups and groups them by DocID
+   * @param candidates
+   * @returns Map of DocIDs to Candidate objects
+   */
+  _groupCandidatesByDocId(candidates: Candidate[]): Map<string, Candidate[]> {
+    const groupedCandidates: Map<string, Candidate[]> = new Map();
 
-        const candidate = new Candidate(new CID(request.cid), request.id, doc);
+    for (const candidate of candidates) {
         const candidateArr = groupedCandidates.get(candidate.docId) || []
         candidateArr.push(candidate)
         groupedCandidates.set(candidate.docId, candidateArr)
-      } catch (e) {
-        logger.err(`Error while loading document ${docId?.baseID.toString()} at commit ${docId?.commit.toString()}. Error: ${e.toString()}`)
-        await this.requestRepository.updateRequests({
-          status: RS.FAILED,
-          message: "Request has failed. " + e.toString(),
-        }, [request]);
-      }
     }
     return groupedCandidates
   }
 
   /**
+   * Given a Request, loads the corresponding Ceramic Stream and returns a Candidate object for
+   * this Request. Also handles updating the requests database if loading the stream fails.
+   * @param request
+   */
+  async _loadCandidateForRequest(request: Request): Promise<Candidate | null> {
+    let docId
+    try {
+      docId = this._getRequestDocID(request)
+      const doc = await this.ceramicService.loadDocument(docId)
+      if (!doc) {
+        throw new Error(`No valid ceramic document found with docId ${docId.toString()}`)
+      }
+
+      return new Candidate(new CID(request.cid), request.id, doc);
+    } catch (e) {
+      logger.err(`Error while loading document ${docId?.baseID.toString()} at commit ${docId?.commit.toString()}. Error: ${e.toString()}`)
+      await this.requestRepository.updateRequests({
+        status: RS.FAILED,
+        message: "Request has failed. " + e.toString(),
+      }, [request]);
+    }
+  }
+
+  /**
    * Selects which Candidate CID should be anchored for each docId
-   * @param groupedCandidates - map of ceramic docId to array of Candidates each representing one anchor request for that docId
+   * @param candidates - List of Candidates each representing one anchor request
    * @return a tuple whose first element is an array of the Candidates that were selected for anchoring,
    *   and whose second element is an array of Candidates that were rejected by the conflict resolution rules
    */
-  async _selectValidCandidates(groupedCandidates: Map<string, Candidate[]>): Promise<[Candidate[], Candidate[]]> {
+  async _selectValidCandidates(candidates: Candidate[]): Promise<[Candidate[], Candidate[]]> {
+    const groupedCandidates = this._groupCandidatesByDocId(candidates)
     const selectedCandidates: Candidate[] = [];
     const conflictingCandidates: Candidate[] = []
 


### PR DESCRIPTION
It may be easier to review this PR by reviewing the two commits that go into it one at a time. The first refactors the code without any functionality change, the second changes the way we load streams to add parallelism.