### PR TITLE
fix(cas): Estimate gas based on the txn request

### DIFF
--- a/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
+++ b/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
@@ -80,7 +80,7 @@ export default class EthereumBlockchainService implements BlockchainService {
       txData.gasLimit = BigNumber.from(config.blockchain.connectors.ethereum.gasLimit);
       logger.debug('Overriding Gas limit: ' + txData.gasLimit.toString());
     } else {
-      const gasPriceEstimate = await this.wallet.provider.getGasPrice(); // in wei
+      const gasPriceEstimate = await this.wallet.provider.estimateGas(txData); // in wei
       // Add extra to gas price for each subsequent attempt
       txData.gasPrice = EthereumBlockchainService.increaseGasPricePerAttempt(
         gasPriceEstimate, attempt, txData.gasPrice)


### PR DESCRIPTION
It looks like we've been using the `ethers` library wrong in terms of how we've been doing our gas price estimation. We've been using the [getGasPrice](https://github.com/ethers-io/ethers.js/blob/d3b7130ed6ec50b192eb7f33905eaa327d65eee2/packages/abstract-provider/src.ts/index.ts#L217) method which returns the gas price of the previous block (I think), but there is also an [estimateGas](https://github.com/ethers-io/ethers.js/blob/d3b7130ed6ec50b192eb7f33905eaa327d65eee2/packages/abstract-provider/src.ts/index.ts#L228) method which takes information about the transaction you are trying to perform and explicitly estimates the amount of gas needed for it.