### PR TITLE
fix(cas): Always confirm all previous txn attempts after nonce error

### DIFF
--- a/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
+++ b/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
@@ -216,12 +216,6 @@ export default class EthereumBlockchainService implements BlockchainService {
         return await this._confirmTransactionSuccess(txResponses[i], network, transactionTimeoutSecs)
       } catch (err) {
         logger.err(err);
-
-        if (err.code == ErrorCode.NONCE_EXPIRED) {
-          continue
-        } else {
-          throw err
-        }
       }
     }
   }

--- a/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
+++ b/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
@@ -218,6 +218,7 @@ export default class EthereumBlockchainService implements BlockchainService {
         logger.err(err);
       }
     }
+    throw new Error("Failed to confirm any previous transaction attempts")
   }
 
 


### PR DESCRIPTION
This most likely would have made last night's mainnet CAS anchor batch succeed