### PR TITLE
fix(cas): Don't use bad HTTP status when request doesn't exist

### DIFF
--- a/src/controllers/request-controller.ts
+++ b/src/controllers/request-controller.ts
@@ -40,7 +40,7 @@ export default class RequestController {
           const body = await this.#requestPresentation.body(request);
           return res.status(StatusCodes.OK).json(body);
         } else {
-          return res.status(StatusCodes.NOT_FOUND).send({
+          return res.status(StatusCodes.OK).send({
             error: "Request doesn't exist",
           });
         }


### PR DESCRIPTION
This makes Ceramic throw an exception rather than just return that the anchor failed, which complicates the error handling code paths