### PR TITLE
CI build and push to dockerhub

### DIFF
--- a/.github/workflows/build_and_push_ecr.yml
+++ b/.github/workflows/build_and_push_ecr.yml
@@ -66,15 +66,15 @@ jobs:
           docker buildx build . --file Dockerfile \
             --output "type=image,push=true" \
             --tag cas \
-            --tag ${{ env.IMAGE_ID }}:${{ env.IMAGE_TAG }} \
-            --tag ${{ env.IMAGE_ID }}:${{ env.IMAGE_TAG_2 }} \
+            --tag ${{ env.IMAGE_ID }}:${{ steps.set-vars.outputs.IMAGE_TAG }} \
+            --tag ${{ env.IMAGE_ID }}:${{ steps.set-vars.outputs.IMAGE_TAG_2 }} \
             --tag ${{ env.IMAGE_ID }}:${{ env.SHA_TAG }}
           docker build -f Dockerfile.runner -t $ECR_REGISTRY/$ECR_REPOSITORY:$SHA_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.set-vars.outputs.IMAGE_TAG }} -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.set-vars.outputs.IMAGE_TAG_2 }} .
         else
           docker buildx build . --file Dockerfile \
             --output "type=image,push=true" \
             --tag cas \
-            --tag ${{ env.IMAGE_ID }}:${{ env.IMAGE_TAG }} \
+            --tag ${{ env.IMAGE_ID }}:${{ steps.set-vars.outputs.IMAGE_TAG }} \
             --tag ${{ env.IMAGE_ID }}:${{ env.SHA_TAG }}
           docker build -f Dockerfile.runner -t $ECR_REGISTRY/$ECR_REPOSITORY:$SHA_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.set-vars.outputs.IMAGE_TAG }} .
         fi

--- a/.github/workflows/build_and_push_ecr.yml
+++ b/.github/workflows/build_and_push_ecr.yml
@@ -4,7 +4,6 @@ on:
       - main
       - "release-candidate"
       - develop
-      - feat/ci
   workflow_dispatch:
 
 name: Build and Push Images
@@ -30,11 +29,11 @@ jobs:
         elif [[ "${{github.base_ref}}" == "release-candidate" || "${{github.ref}}" == "refs/heads/release-candidate" ]]; then
           echo "::set-output name=ECR_REPOSITORY::ceramic-tnet-cas"
           echo "::set-output name=IMAGE_TAG::tnet"
-          echo "::set-output name=IMAGE_TAG_2::none"
+          echo "::set-output name=IMAGE_TAG_2::release-candidate"
         else
           echo "::set-output name=ECR_REPOSITORY::ceramic-dev-cas"
           echo "::set-output name=IMAGE_TAG::dev"
-          echo "::set-output name=IMAGE_TAG_2::none"
+          echo "::set-output name=IMAGE_TAG_2::develop"
         fi
 
     - name: Login to DockerHub

--- a/.github/workflows/build_and_push_ecr.yml
+++ b/.github/workflows/build_and_push_ecr.yml
@@ -55,24 +55,18 @@ jobs:
     - name: Build, tag, and push image to Amazon ECR
       id: build-image
       env:
-        IMAGE_ID: "ceramicnetwork/ceramic-anchor-service"
-        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        ECR_REPOSITORY: ${{ steps.set-vars.outputs.ECR_REPOSITORY }}
+        DOCKERHUB_IMAGE_ID: "ceramicnetwork/ceramic-anchor-service"
+        ECR_IMAGE_ID: "${{ steps.login-ecr.outputs.registry }}/${{ steps.set-vars.outputs.ECR_REPOSITORY }}"
         SHA_TAG: ${{ github.sha }}
+        IMAGE_TAG: ${{ steps.set-vars.outputs.IMAGE_TAG }}
+        IMAGE_TAG_2: ${{ steps.set-vars.outputs.IMAGE_TAG_2 }}
       run: |
         if [[ "${{steps.set-vars.outputs.IMAGE_TAG_2}}" != "none" ]]; then
-          docker build -f Dockerfile 
-            --tag cas \
-            --tag ${{ env.IMAGE_ID }}:${{ steps.set-vars.outputs.IMAGE_TAG }} \
-            --tag ${{ env.IMAGE_ID }}:${{ steps.set-vars.outputs.IMAGE_TAG_2 }} \
-            --tag ${{ env.IMAGE_ID }}:${{ env.SHA_TAG }} .
-          docker build -f Dockerfile.runner -t $ECR_REGISTRY/$ECR_REPOSITORY:$SHA_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.set-vars.outputs.IMAGE_TAG }} -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.set-vars.outputs.IMAGE_TAG_2 }} .
+          docker build -f Dockerfile -t cas -t $DOCKERHUB_IMAGE_ID:$SHA_TAG -t $DOCKERHUB_IMAGE_ID:$IMAGE_TAG -t $DOCKERHUB_IMAGE_ID:$IMAGE_TAG_2 .
+          docker build -f Dockerfile.runner -t $ECR_IMAGE_ID:$SHA_TAG -t $ECR_IMAGE_ID:$IMAGE_TAG -t $ECR_IMAGE_ID:$IMAGE_TAG_2 .
         else
-          docker build -f Dockerfile 
-            --tag cas \
-            --tag ${{ env.IMAGE_ID }}:${{ steps.set-vars.outputs.IMAGE_TAG }} \
-            --tag ${{ env.IMAGE_ID }}:${{ env.SHA_TAG }} .
-          docker build -f Dockerfile.runner -t $ECR_REGISTRY/$ECR_REPOSITORY:$SHA_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.set-vars.outputs.IMAGE_TAG }} .
+          docker build -f Dockerfile -t cas -t $DOCKERHUB_IMAGE_ID:$SHA_TAG -t $DOCKERHUB_IMAGE_ID:$IMAGE_TAG .
+          docker build -f Dockerfile.runner -t $ECR_IMAGE_ID:$SHA_TAG -t $ECR_IMAGE_ID:$IMAGE_TAG .
         fi
-        docker push $IMAGE_ID --all-tags
-        docker push $ECR_REGISTRY/$ECR_REPOSITORY --all-tags
+        docker push $DOCKERHUB_IMAGE_ID --all-tags
+        docker push $ECR_IMAGE_ID --all-tags

--- a/.github/workflows/build_and_push_ecr.yml
+++ b/.github/workflows/build_and_push_ecr.yml
@@ -21,6 +21,8 @@ jobs:
     - name: Set Variables
       id: set-vars
       run: |
+        SHA_TAG=$(git rev-parse --short=12 "${{ github.sha }}")
+        echo "SHA_TAG=$SHA_TAG" >> $GITHUB_ENV
         if [[ "${{github.base_ref}}" == "main" || "${{github.ref}}" == "refs/heads/main" ]]; then
           echo "::set-output name=ECR_REPOSITORY::ceramic-prod-cas"
           echo "::set-output name=IMAGE_TAG::latest"
@@ -33,9 +35,6 @@ jobs:
           echo "::set-output name=ECR_REPOSITORY::ceramic-dev-cas"
           echo "::set-output name=IMAGE_TAG::dev"
           echo "::set-output name=IMAGE_TAG_2::none"
-        then
-          SHA_TAG=$(git rev-parse --short=12 "${{ github.sha }}")
-          echo "SHA_TAG=$SHA_TAG" >> $GITHUB_ENV
         fi
 
     - name: Login to DockerHub

--- a/.github/workflows/build_and_push_ecr.yml
+++ b/.github/workflows/build_and_push_ecr.yml
@@ -4,6 +4,7 @@ on:
       - main
       - "release-candidate"
       - develop
+      - feat/ci
   workflow_dispatch:
 
 name: Build and Push Images

--- a/.github/workflows/build_and_push_ecr.yml
+++ b/.github/workflows/build_and_push_ecr.yml
@@ -35,9 +35,6 @@ jobs:
           echo "::set-output name=IMAGE_TAG_2::none"
         fi
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-
     - name: Login to DockerHub
       uses: docker/login-action@v1 
       with:
@@ -64,19 +61,18 @@ jobs:
         SHA_TAG: ${{ github.sha }}
       run: |
         if [[ "${{steps.set-vars.outputs.IMAGE_TAG_2}}" != "none" ]]; then
-          docker buildx build . --file Dockerfile \
-            --output "type=image,push=true" \
+          docker build -f Dockerfile 
             --tag cas \
             --tag ${{ env.IMAGE_ID }}:${{ steps.set-vars.outputs.IMAGE_TAG }} \
             --tag ${{ env.IMAGE_ID }}:${{ steps.set-vars.outputs.IMAGE_TAG_2 }} \
-            --tag ${{ env.IMAGE_ID }}:${{ env.SHA_TAG }}
+            --tag ${{ env.IMAGE_ID }}:${{ env.SHA_TAG }} .
           docker build -f Dockerfile.runner -t $ECR_REGISTRY/$ECR_REPOSITORY:$SHA_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.set-vars.outputs.IMAGE_TAG }} -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.set-vars.outputs.IMAGE_TAG_2 }} .
         else
-          docker buildx build . --file Dockerfile \
-            --output "type=image,push=true" \
+          docker build -f Dockerfile 
             --tag cas \
             --tag ${{ env.IMAGE_ID }}:${{ steps.set-vars.outputs.IMAGE_TAG }} \
-            --tag ${{ env.IMAGE_ID }}:${{ env.SHA_TAG }}
+            --tag ${{ env.IMAGE_ID }}:${{ env.SHA_TAG }} .
           docker build -f Dockerfile.runner -t $ECR_REGISTRY/$ECR_REPOSITORY:$SHA_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.set-vars.outputs.IMAGE_TAG }} .
         fi
+        docker push $IMAGE_ID --all-tags
         docker push $ECR_REGISTRY/$ECR_REPOSITORY --all-tags

--- a/.github/workflows/build_and_push_ecr.yml
+++ b/.github/workflows/build_and_push_ecr.yml
@@ -33,6 +33,9 @@ jobs:
           echo "::set-output name=ECR_REPOSITORY::ceramic-dev-cas"
           echo "::set-output name=IMAGE_TAG::dev"
           echo "::set-output name=IMAGE_TAG_2::none"
+        then
+          SHA_TAG=$(git rev-parse --short=12 "${{ github.sha }}")
+          echo "SHA_TAG=$SHA_TAG" >> $GITHUB_ENV
         fi
 
     - name: Login to DockerHub
@@ -57,7 +60,6 @@ jobs:
       env:
         DOCKERHUB_IMAGE_ID: "ceramicnetwork/ceramic-anchor-service"
         ECR_IMAGE_ID: "${{ steps.login-ecr.outputs.registry }}/${{ steps.set-vars.outputs.ECR_REPOSITORY }}"
-        SHA_TAG: ${{ github.sha }}
         IMAGE_TAG: ${{ steps.set-vars.outputs.IMAGE_TAG }}
         IMAGE_TAG_2: ${{ steps.set-vars.outputs.IMAGE_TAG_2 }}
       run: |


### PR DESCRIPTION
### Motivation

Clean (and speed) up build and pushing docker images to prevent accidental updates and keep track of revisions better

### Changes

Not using Dockerhub's automate build tool anymore. Instead added logic here to build the CAS image used by the anchor task and push it to Dockerhub