### PR TITLE
chore(cas): Do not rely on process wide globals

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "lint": "./node_modules/.bin/eslint --fix ./src --ext .js,.jsx,.ts,.tsx",
     "typeorm": "ts-node -r tsconfig-paths/register ./node_modules//typeorm/cli.js",
     "clean": "rm -rf ./build; rm -rf coverage; rm -rf .nyc_output",
-    "start": "node ./build/app.js",
-    "startDev": "NODE_ENV=dev APP_MODE=bundled node ./build/app.js ",
+    "start": "node ./build/main.js",
+    "startDev": "NODE_ENV=dev APP_MODE=bundled node ./build/main.js ",
     "watch": "nodemon -e ts --watch src --exec \"npm run build && npm run start\"",
     "release": "release-it --verbose --disable-metrics"
   },

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,7 @@ require('dotenv').config();
 const packageJson = require('../package.json')
 
 import { config } from 'node-config-ts';
-import { container, instanceCachingFactory } from 'tsyringe';
+import { container, instanceCachingFactory, DependencyContainer } from 'tsyringe';
 
 import { logger } from "./logger";
 import CeramicAnchorServer from './server';
@@ -34,7 +34,8 @@ initializeTransactionalContext();
  * Ceramic Anchor Service application
  */
 export default class CeramicAnchorApp {
-  constructor() {
+
+  constructor(private readonly container: DependencyContainer) {
     CeramicAnchorApp._normalizeConfig();
 
     // TODO: Selectively register only the global singletons needed based on the config
@@ -192,7 +193,7 @@ export default class CeramicAnchorApp {
   }
 }
 
-const app = new CeramicAnchorApp();
+const app = new CeramicAnchorApp(container);
 app.start()
   .catch((e) => {
     logger.err(e);

--- a/src/controllers/request-controller.ts
+++ b/src/controllers/request-controller.ts
@@ -1,7 +1,7 @@
 import { StatusCodes } from 'http-status-codes';
 import { Request as ExpReq, Response as ExpRes } from 'express';
 
-import { config } from 'node-config-ts';
+import { Config } from 'node-config-ts';
 
 import cors from 'cors';
 import { ClassMiddleware, Controller, Get, Post } from '@overnightjs/core';
@@ -22,6 +22,7 @@ export default class RequestController {
   #requestPresentation: RequestPresentation;
 
   constructor(
+    @inject('config') private config?: Config,
     @inject('anchorRepository') private anchorRepository?: AnchorRepository,
     @inject('requestRepository') private requestRepository?: RequestRepository,
   ) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,10 @@
 import CeramicAnchorApp from './app';
 import { logger } from "./logger";
 
+import { config } from 'node-config-ts';
 import { container } from 'tsyringe';
 
-const app = new CeramicAnchorApp(container);
+const app = new CeramicAnchorApp(container, config);
 app.start()
   .catch((e) => {
     logger.err(e);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,11 @@
+import CeramicAnchorApp from './app';
+import { logger } from "./logger";
+
+import { container } from 'tsyringe';
+
+const app = new CeramicAnchorApp(container);
+app.start()
+  .catch((e) => {
+    logger.err(e);
+    process.exit(1);
+  });

--- a/src/models/request-presentation.ts
+++ b/src/models/request-presentation.ts
@@ -1,7 +1,6 @@
 import AnchorRepository from '../repositories/anchor-repository';
 import { InvalidRequestStatusError, RequestStatus } from './request-status';
 import awsCronParser from 'aws-cron-parser';
-import { config } from 'node-config-ts';
 import { Request } from './request';
 
 /**
@@ -39,7 +38,7 @@ export class RequestPresentation {
         };
       }
       case RequestStatus.PENDING: {
-        const cron = awsCronParser.parse(config.cronExpression);
+        const cron = awsCronParser.parse(this.cronExpression);
         return {
           id: request.id,
           status: RequestStatus[request.status],

--- a/src/repositories/request-repository.ts
+++ b/src/repositories/request-repository.ts
@@ -5,12 +5,17 @@ import { BaseRepository } from 'typeorm-transactional-cls-hooked';
 import { Request, RequestUpdateFields } from "../models/request";
 import { RequestStatus } from "../models/request-status";
 import { logEvent } from '../logger';
-import { config } from "node-config-ts";
-import { singleton } from "tsyringe";
+import { Config } from 'node-config-ts';
+import { inject, singleton } from 'tsyringe';
 
 @singleton()
 @EntityRepository(Request)
 export default class RequestRepository extends BaseRepository<Request> {
+
+  constructor(
+    @inject('config') private config?: Config) {
+    super()
+  }
 
   /**
    * Create/updates client request
@@ -65,7 +70,7 @@ export default class RequestRepository extends BaseRepository<Request> {
    */
   public async findNextToProcess(): Promise<Request[]> {
     const now: number = new Date().getTime();
-    const deadlineDate = new Date(now - config.expirationPeriod);
+    const deadlineDate = new Date(now - this.config.expirationPeriod);
 
     return await this.manager.getRepository(Request)
       .createQueryBuilder("request")

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import * as bodyParser from 'body-parser';
 import { Server } from '@overnightjs/core';
 
-import { config } from "node-config-ts";
+import { Config } from "node-config-ts";
 
 import AnchorController from "./controllers/anchor-controller";
 import RequestController from "./controllers/request-controller";
@@ -30,6 +30,7 @@ export default class CeramicAnchorServer extends Server {
    * @param port - Server listening port
    */
   public async start(port?: number): Promise<void> {
+    const config = this.container.resolve<Config>('config')
     const requestController = this.container.resolve<RequestController>('requestController');
     const serviceInfoController = this.container.resolve<ServiceInfoController>('serviceInfoController');
     const healthcheckController = this.container.resolve<HealthcheckController>('healthcheckController');

--- a/src/services/__tests__/anchor-service.test.ts
+++ b/src/services/__tests__/anchor-service.test.ts
@@ -2,7 +2,7 @@ import 'reflect-metadata';
 
 process.env.NODE_ENV = 'test';
 
-import { container } from "tsyringe";
+import { container, instanceCachingFactory } from 'tsyringe';
 
 import { Request } from "../../models/request";
 import { RequestStatus } from "../../models/request-status";
@@ -17,7 +17,7 @@ import { initializeTransactionalContext } from 'typeorm-transactional-cls-hooked
 import RequestRepository from "../../repositories/request-repository";
 import { IpfsService } from "../ipfs-service";
 import AnchorRepository from "../../repositories/anchor-repository";
-import { config } from 'node-config-ts';
+import { config, Config } from 'node-config-ts';
 import { StreamID } from '@ceramicnetwork/streamid';
 import { MockCeramicService, MockIpfsService } from '../../test-utils';
 
@@ -48,6 +48,7 @@ describe('ETH service',  () => {
     ipfsService = new MockIpfsService()
     ceramicService = new MockCeramicService()
 
+    container.registerInstance("config", config)
     container.registerSingleton("anchorRepository", AnchorRepository);
     container.registerSingleton("requestRepository", RequestRepository);
     container.registerSingleton("blockchainService", EthereumBlockchainService);

--- a/src/services/blockchain/__tests__/eth-bc-service.test.ts
+++ b/src/services/blockchain/__tests__/eth-bc-service.test.ts
@@ -21,7 +21,7 @@ describe('ETH service connected to ganache',  () => {
 
   beforeAll(async () => {
     container.register("blockchainService", {
-      useFactory: instanceCachingFactory<EthereumBlockchainService>(c => EthereumBlockchainService.make())
+      useFactory: instanceCachingFactory<EthereumBlockchainService>(c => EthereumBlockchainService.make(config))
     });
 
     ethBc = container.resolve<BlockchainService>('blockchainService');
@@ -109,7 +109,7 @@ describe('ETH service with mock wallet',  () => {
   }
 
   beforeEach(async () => {
-    ethBc = new EthereumBlockchainService(wallet as any)
+    ethBc = new EthereumBlockchainService(config, wallet as any)
 
     provider.getNetwork.mockReturnValue({chainId: "1337"})
     await ethBc.connect()

--- a/src/services/ceramic-service.ts
+++ b/src/services/ceramic-service.ts
@@ -1,7 +1,7 @@
 import CeramicClient from '@ceramicnetwork/http-client';
 import { CeramicApi, Stream, SyncOptions } from '@ceramicnetwork/common';
 
-import { config } from "node-config-ts";
+import { Config } from "node-config-ts";
 import { inject, singleton } from "tsyringe";
 import { IpfsService } from "./ipfs-service";
 import { StreamID, CommitID } from '@ceramicnetwork/streamid';
@@ -19,7 +19,8 @@ export default class CeramicServiceImpl implements CeramicService {
   /**
    * Sets dependencies
    */
-  constructor(@inject('ipfsService') private ipfsService?: IpfsService) {
+  constructor(@inject('config') private config?: Config,
+              @inject('ipfsService') private ipfsService?: IpfsService) {
     this._client = new CeramicClient(config.ceramic.apiUrl);
   }
 

--- a/src/services/scheduler-service.ts
+++ b/src/services/scheduler-service.ts
@@ -1,6 +1,6 @@
 import awsCronParser from "aws-cron-parser";
 
-import { config } from 'node-config-ts';
+import { Config } from 'node-config-ts';
 
 import AnchorService from './anchor-service';
 import { logger } from '../logger';
@@ -13,7 +13,8 @@ import { inject, singleton } from "tsyringe";
 export default class SchedulerService {
 
   constructor(
-    @inject("anchorService") private anchorService?: AnchorService) {
+    @inject("anchorService") private anchorService?: AnchorService,
+    @inject('config') private config?: Config) {
   }
 
   /**
@@ -22,7 +23,7 @@ export default class SchedulerService {
    * Note: setInterval() can be refactored to consecutive setTimeout(s) to avoid anchoring clashing.
    */
   public start(): void {
-    const cron = awsCronParser.parse(config.cronExpression);
+    const cron = awsCronParser.parse(this.config.cronExpression);
     let nextScheduleTime = awsCronParser.next(cron, new Date()).getTime();
 
     setInterval(async () => {


### PR DESCRIPTION
Instead of relying on the global dependency injection `container` object, pass the container explicitly.
Instead of relying on the global `config` object, register the config with the dependency injection container and resolve it wherever needed.

Not the cleanest, but seemed the shortest path to allowing multiple CAS instances to coexist in the same process space