### PR TITLE
fix: optimize build time during (repeat) docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,11 @@ RUN apt-get update && apt-get install -y netcat
 
 WORKDIR /cas
 
-COPY . /cas
+COPY package.json package-lock.json /cas/
 
-RUN npm install
+RUN npm ci
+
+COPY . /cas
 
 RUN npm run postinstall
 


### PR DESCRIPTION
* use `npm ci`, instead of `npm install` so the dependency versions are always locked.

* By copying only `package.json` and `package-lock.json` as a separate step, we reuse cache for 'npm ci' (ie, npm install).
  - This saves build time, bandwidth when we are doing docker build as the way to test locally for new developments (if any).
  - Specially helpful when the resulting image is immediately tested with clayground.
  - This also improves the build time.

Signed-off-by: Amar Tumballi <amar@dhiway.com>