### PR TITLE
chore(cas): Clean up IPFS initialization

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -104,6 +104,10 @@ export default class CeramicAnchorApp {
     return configCopy
   }
 
+  private _shouldStartIpfs(): Boolean {
+    return this.config.mode == "anchor" || this.config.mode == "bundled" || this.config.anchorControllerEnabled;
+  }
+
   /**
    * Start application
    */
@@ -114,8 +118,10 @@ export default class CeramicAnchorApp {
     const blockchainService: BlockchainService = this.container.resolve<BlockchainService>('blockchainService');
     await blockchainService.connect();
 
-    const ipfsService: IpfsServiceImpl = this.container.resolve<IpfsServiceImpl>('ipfsService');
-    await ipfsService.init();
+    if (this._shouldStartIpfs()) {
+      const ipfsService: IpfsServiceImpl = this.container.resolve<IpfsServiceImpl>('ipfsService');
+      await ipfsService.init();
+    }
 
     switch (this.config.mode) {
       case 'server': {

--- a/src/app.ts
+++ b/src/app.ts
@@ -54,7 +54,7 @@ export default class CeramicAnchorApp {
       useFactory: instanceCachingFactory<EthereumBlockchainService>(c => EthereumBlockchainService.make(config))
     });
     container.registerSingleton("anchorService", AnchorService);
-    if (config.mode == "bundled" || config.mode == "anchor" || config.anchorControllerEnabled) {
+    if (this._anchorsSupported()) {
       // Only register the ceramicService if we might ever need to perform an anchor
       container.registerSingleton("ceramicService", CeramicServiceImpl);
     }
@@ -104,7 +104,11 @@ export default class CeramicAnchorApp {
     return configCopy
   }
 
-  private _shouldStartIpfs(): Boolean {
+  /**
+   * Returns true when we're running in a config that may do an anchor.
+   * @private
+   */
+  private _anchorsSupported(): Boolean {
     return this.config.mode == "anchor" || this.config.mode == "bundled" || this.config.anchorControllerEnabled;
   }
 
@@ -118,7 +122,7 @@ export default class CeramicAnchorApp {
     const blockchainService: BlockchainService = this.container.resolve<BlockchainService>('blockchainService');
     await blockchainService.connect();
 
-    if (this._shouldStartIpfs()) {
+    if (this._anchorsSupported()) {
       const ipfsService: IpfsServiceImpl = this.container.resolve<IpfsServiceImpl>('ipfsService');
       await ipfsService.init();
     }

--- a/src/app.ts
+++ b/src/app.ts
@@ -114,6 +114,9 @@ export default class CeramicAnchorApp {
     const blockchainService: BlockchainService = this.container.resolve<BlockchainService>('blockchainService');
     await blockchainService.connect();
 
+    const ipfsService: IpfsServiceImpl = this.container.resolve<IpfsServiceImpl>('ipfsService');
+    await ipfsService.init();
+
     switch (this.config.mode) {
       case 'server': {
         await this._startServer();
@@ -140,9 +143,6 @@ export default class CeramicAnchorApp {
    * @private
    */
   private async _startBundled(): Promise<void> {
-    const ipfsService: IpfsServiceImpl = this.container.resolve<IpfsServiceImpl>('ipfsService');
-    await ipfsService.init();
-
     const schedulerService: SchedulerService = this.container.resolve<SchedulerService>('schedulerService');
     schedulerService.start();
     await this._startServer();
@@ -164,9 +164,6 @@ export default class CeramicAnchorApp {
    * @private
    */
   private async _startAnchor(): Promise<void> {
-    const ipfsService: IpfsServiceImpl = this.container.resolve<IpfsServiceImpl>('ipfsService');
-    await ipfsService.init();
-
     this.startWithConnectionHandling(async () => {
       const anchorService: AnchorService = this.container.resolve<AnchorService>('anchorService');
       await anchorService.anchorRequests();


### PR DESCRIPTION
This meant that the cas only instructs its ipfs node to subscribe to pubsub when performing an anchor.

Ideally we should probably be making the CAS IPFS node subscribe to pubsub on its own at startup via an environment variable, rather than waiting for a CAS node to instruct it to subscribe. But this will at least add one more case where the ipfs node will get subscribed