### PR TITLE
fix: Unmasking release-candidate and main push on branches

### DIFF
--- a/.github/workflows/build_push_and_restart_cas.yml
+++ b/.github/workflows/build_push_and_restart_cas.yml
@@ -3,8 +3,8 @@ name: build_push_and_restart_cas
 on:
   push:
     branches:
-      ##MASKED## - main
-      ##MASKED## - "release-candidate"
+      - main
+      - "release-candidate"
       - develop
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Tested both push on develop branch works for restart_cas and also with workflow_dispatch with dev environment selection.