### PR TITLE
chore(cas): Don't anchor early when merkle tree full

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3721,6 +3721,14 @@
             "node-fetch": "npm:@achingbrain/node-fetch@^2.6.4",
             "react-native-fetch-api": "^2.0.0",
             "stream-to-it": "^0.2.2"
+          },
+          "dependencies": {
+            "node-fetch": {
+              "version": "npm:@achingbrain/node-fetch@2.6.7",
+              "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+              "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
+              "dev": true
+            }
           }
         },
         "ipld-dag-cbor": {
@@ -3910,10 +3918,9 @@
           "dev": true
         },
         "node-fetch": {
-          "version": "npm:@achingbrain/node-fetch@2.6.7",
+          "version": "npm:node-fetch@2.6.7",
           "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
-          "dev": true
+          "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g=="
         },
         "parse-duration": {
           "version": "1.0.0",
@@ -4306,6 +4313,14 @@
             "node-fetch": "npm:@achingbrain/node-fetch@^2.6.4",
             "react-native-fetch-api": "^2.0.0",
             "stream-to-it": "^0.2.2"
+          },
+          "dependencies": {
+            "node-fetch": {
+              "version": "npm:@achingbrain/node-fetch@2.6.7",
+              "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+              "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
+              "dev": true
+            }
           }
         },
         "ipld-dag-cbor": {
@@ -4483,10 +4498,9 @@
           "dev": true
         },
         "node-fetch": {
-          "version": "npm:@achingbrain/node-fetch@2.6.7",
+          "version": "npm:node-fetch@2.6.7",
           "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
-          "dev": true
+          "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g=="
         },
         "parse-duration": {
           "version": "1.0.0",
@@ -18707,6 +18721,14 @@
                 "string.prototype.trimend": "^1.0.4",
                 "string.prototype.trimstart": "^1.0.4",
                 "unbox-primitive": "^1.0.0"
+              },
+              "dependencies": {
+                "has-symbols": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+                  "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+                  "dev": true
+                }
               }
             },
             "get-intrinsic": {
@@ -18718,6 +18740,50 @@
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
                 "has-symbols": "^1.0.1"
+              }
+            },
+            "is-callable": {
+              "version": "1.2.3",
+              "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+              "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+              "dev": true
+            },
+            "is-regex": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+              "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+              "dev": true,
+              "requires": {
+                "call-bind": "^1.0.2",
+                "has-symbols": "^1.0.2"
+              },
+              "dependencies": {
+                "has-symbols": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+                  "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+                  "dev": true
+                }
+              }
+            },
+            "string.prototype.trimend": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+              "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+              "dev": true,
+              "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+              }
+            },
+            "string.prototype.trimstart": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+              "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+              "dev": true,
+              "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
               }
             }
           }

--- a/src/services/scheduler-service.ts
+++ b/src/services/scheduler-service.ts
@@ -36,10 +36,6 @@ export default class SchedulerService {
           // Always anchor if the scheduled time delay has passed
           await this.anchorService.anchorRequests();
           performedAnchor = true
-        } else {
-          // Even if we're not up to the scheduled anchor time, we may want to anchor early if
-          // we have too many pending requests built up.
-          performedAnchor = await this.anchorService.anchorIfTooManyPendingRequests();
         }
 
         if (performedAnchor) {


### PR DESCRIPTION
Turns out this only happens if you are running in "bundled" mode so wasn't really affecting us much anyway, but taking it out just to be safe