### PR TITLE
Rename anchorRecord to anchorCommit

### DIFF
--- a/src/models/request-presentation.ts
+++ b/src/models/request-presentation.ts
@@ -30,7 +30,7 @@ export class RequestPresentation {
           message: request.message,
           createdAt: request.createdAt.getTime(),
           updatedAt: request.updatedAt.getTime(),
-          anchorRecord: {
+          anchorRecord: {  // TODO: Remove this backwards compatibility field
             cid: anchor.cid,
             content: {
               path: anchor.path,

--- a/src/models/request-presentation.ts
+++ b/src/models/request-presentation.ts
@@ -38,6 +38,14 @@ export class RequestPresentation {
               proof: anchor.proofCid,
             },
           },
+          anchorCommit: {
+            cid: anchor.cid,
+            content: {
+              path: anchor.path,
+              prev: anchor.request.cid,
+              proof: anchor.proofCid,
+            },
+          },
         }
       }
       case RequestStatus.PENDING: {


### PR DESCRIPTION
As requested by Sergeys in the PR https://github.com/ceramicnetwork/js-ceramic/pull/1649. To maintain the backwards compatibility anchorCommit field was added besides the anchorRecord.
This PR also will resolve the issue stated in https://github.com/ceramicnetwork/ceramic-anchor-service/issues/485