### PR TITLE
feat: Recalculate maxFeePerGas via baseFee

### DIFF
--- a/src/services/blockchain/__tests__/__snapshots__/eth-bc-service.test.ts.snap
+++ b/src/services/blockchain/__tests__/__snapshots__/eth-bc-service.test.ts.snap
@@ -109,3 +109,111 @@ Object {
   "to": "abcd1234",
 }
 `;
+
+exports[`setGasPrice EIP1559 transaction 1`] = `
+Object {
+  "data": "0x0f017112205d7fcd1a0999befdb062e6762c1f0f902f729b98304a2ef539412f53360d3d6a",
+  "gasLimit": Object {
+    "hex": "0x0a",
+    "type": "BigNumber",
+  },
+  "maxFeePerGas": Object {
+    "hex": "0x07d0",
+    "type": "BigNumber",
+  },
+  "maxPriorityFeePerGas": Object {
+    "hex": "0x03e8",
+    "type": "BigNumber",
+  },
+  "nonce": undefined,
+  "to": "abcd1234",
+}
+`;
+
+exports[`setGasPrice EIP1559 transaction 2`] = `
+Object {
+  "data": "0x0f017112205d7fcd1a0999befdb062e6762c1f0f902f729b98304a2ef539412f53360d3d6a",
+  "gasLimit": Object {
+    "hex": "0x0a",
+    "type": "BigNumber",
+  },
+  "maxFeePerGas": Object {
+    "hex": "0x0834",
+    "type": "BigNumber",
+  },
+  "maxPriorityFeePerGas": Object {
+    "hex": "0x044c",
+    "type": "BigNumber",
+  },
+  "nonce": undefined,
+  "to": "abcd1234",
+}
+`;
+
+exports[`setGasPrice EIP1559 transaction 3`] = `
+Object {
+  "data": "0x0f017112205d7fcd1a0999befdb062e6762c1f0f902f729b98304a2ef539412f53360d3d6a",
+  "gasLimit": Object {
+    "hex": "0x0a",
+    "type": "BigNumber",
+  },
+  "maxFeePerGas": Object {
+    "hex": "0x08a2",
+    "type": "BigNumber",
+  },
+  "maxPriorityFeePerGas": Object {
+    "hex": "0x04ba",
+    "type": "BigNumber",
+  },
+  "nonce": undefined,
+  "to": "abcd1234",
+}
+`;
+
+exports[`setGasPrice legacy transaction 1`] = `
+Object {
+  "data": "0x0f017112205d7fcd1a0999befdb062e6762c1f0f902f729b98304a2ef539412f53360d3d6a",
+  "gasLimit": Object {
+    "hex": "0x0a",
+    "type": "BigNumber",
+  },
+  "gasPrice": Object {
+    "hex": "0x03e8",
+    "type": "BigNumber",
+  },
+  "nonce": undefined,
+  "to": "abcd1234",
+}
+`;
+
+exports[`setGasPrice legacy transaction 2`] = `
+Object {
+  "data": "0x0f017112205d7fcd1a0999befdb062e6762c1f0f902f729b98304a2ef539412f53360d3d6a",
+  "gasLimit": Object {
+    "hex": "0x0a",
+    "type": "BigNumber",
+  },
+  "gasPrice": Object {
+    "hex": "0x044c",
+    "type": "BigNumber",
+  },
+  "nonce": undefined,
+  "to": "abcd1234",
+}
+`;
+
+exports[`setGasPrice legacy transaction 3`] = `
+Object {
+  "data": "0x0f017112205d7fcd1a0999befdb062e6762c1f0f902f729b98304a2ef539412f53360d3d6a",
+  "gasLimit": Object {
+    "hex": "0x0a",
+    "type": "BigNumber",
+  },
+  "gasPrice": Object {
+    "hex": "0x04ba",
+    "type": "BigNumber",
+  },
+  "nonce": undefined,
+  "to": "abcd1234",
+}
+`;

--- a/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
+++ b/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
@@ -206,9 +206,9 @@ export default class EthereumBlockchainService implements BlockchainService {
           attempt,
           prevPriorityFee
         )
-        const priorityFeeDifference = nextPriorityFee.sub(prevPriorityFee)
-        txData.maxFeePerGas = feeData.maxFeePerGas.add(priorityFeeDifference)
         txData.maxPriorityFeePerGas = nextPriorityFee
+        const baseFee = feeData.maxFeePerGas.sub(feeData.maxPriorityFeePerGas)
+        txData.maxFeePerGas = baseFee.add(nextPriorityFee)
         logger.debug(
           `Estimated maxPriorityFeePerGas: ${nextPriorityFee.toString()} wei; maxFeePerGas: ${txData.maxFeePerGas.toString()} wei`
         )


### PR DESCRIPTION
Use more straight-forward calculation of maxFeePerGas. It does not depend now on previous transaction fee.