### PR TITLE
fix: Only mark selected requests as processing

### DIFF
--- a/src/repositories/request-repository.ts
+++ b/src/repositories/request-repository.ts
@@ -93,7 +93,7 @@ export default class RequestRepository extends Repository<Request> {
   /**
    * Gets all requests by status
    */
-  public async findNextToProcess(): Promise<Request[]> {
+  public async findNextToProcess(limit: number): Promise<Request[]> {
     const now: number = new Date().getTime()
     const deadlineDate = new Date(now - this.config.expirationPeriod)
 
@@ -106,6 +106,7 @@ export default class RequestRepository extends Repository<Request> {
         processingStatus: RequestStatus.PROCESSING,
         deadlineDate: deadlineDate.toISOString(),
       })
+      .limit(limit)
       .getMany()
   }
 

--- a/src/services/__tests__/anchor-service.test.ts
+++ b/src/services/__tests__/anchor-service.test.ts
@@ -126,7 +126,7 @@ describe('anchor service', () => {
     request = await requestRepository.findByCid(cid)
     expect(request).toHaveProperty('status', RequestStatus.PROCESSING)
 
-    const requests = await requestRepository.findNextToProcess()
+    const requests = await requestRepository.findNextToProcess(100)
     expect(requests).toBeDefined()
     expect(requests).toBeInstanceOf(Array)
     expect(requests).toHaveLength(1)
@@ -198,7 +198,7 @@ describe('anchor service', () => {
     }
 
     // First pass anchors half the pending requests
-    let requests = await requestRepository.findNextToProcess()
+    let requests = await requestRepository.findNextToProcess(100)
     expect(requests.length).toEqual(numRequests)
     const anchorPendingRequests = async function (requests: Request[]): Promise<void> {
       const candidates = await anchorService._findCandidates(requests, anchorLimit)
@@ -208,14 +208,14 @@ describe('anchor service', () => {
     }
     await anchorPendingRequests(requests)
 
-    requests = await requestRepository.findNextToProcess()
+    requests = await requestRepository.findNextToProcess(100)
     expect(requests.length).toEqual(numRequests / 2)
 
     // Second pass anchors the remaining half of the original requests
     await anchorPendingRequests(requests)
 
     // All requests should have been processed
-    requests = await requestRepository.findNextToProcess()
+    requests = await requestRepository.findNextToProcess(100)
     expect(requests.length).toEqual(0)
   })
 
@@ -237,14 +237,14 @@ describe('anchor service', () => {
       ceramicService.putStream(commitId, stream)
     }
 
-    let requests = await requestRepository.findNextToProcess()
+    let requests = await requestRepository.findNextToProcess(100)
     expect(requests.length).toEqual(numRequests)
     const candidates = await anchorService._findCandidates(requests, anchorLimit)
     expect(candidates.length).toEqual(numRequests)
     await anchorCandidates(candidates, anchorService, ipfsService)
 
     // All requests should have been processed
-    requests = await requestRepository.findNextToProcess()
+    requests = await requestRepository.findNextToProcess(100)
     expect(requests.length).toEqual(0)
   })
 
@@ -282,9 +282,9 @@ describe('anchor service', () => {
     const request1 = await requestRepository.findByCid(new CID(requests[1].cid))
     const request2 = await requestRepository.findByCid(new CID(requests[2].cid))
     const request3 = await requestRepository.findByCid(new CID(requests[3].cid))
-    expect(request0.status).toEqual(RequestStatus.PENDING)
+    expect(request0.status).toEqual(RequestStatus.PROCESSING)
     expect(request1.status).toEqual(RequestStatus.FAILED)
-    expect(request2.status).toEqual(RequestStatus.PENDING)
+    expect(request2.status).toEqual(RequestStatus.PROCESSING)
     expect(request3.status).toEqual(RequestStatus.FAILED)
   })
 
@@ -304,7 +304,7 @@ describe('anchor service', () => {
       ceramicService.putStream(commitId, stream)
     }
 
-    const requests = await requestRepository.findNextToProcess()
+    const requests = await requestRepository.findNextToProcess(100)
     expect(requests.length).toEqual(numRequests)
     const candidates = await anchorService._findCandidates(requests, 0)
     expect(candidates.length).toEqual(numRequests)

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -74,7 +74,7 @@ export default class AnchorService {
     }
 
     const nodeLimit = Math.pow(2, this.config.merkleDepthLimit)
-    const requestLimit = 10 * nodeLimit
+    const requestLimit = 2 * nodeLimit
     const requests: Request[] = await this.requestRepository.findNextToProcess(requestLimit)
     if (requests.length > nodeLimit) {
       logger.imp(
@@ -100,11 +100,11 @@ export default class AnchorService {
   public async anchorRequests(): Promise<void> {
     // We try to fill our batch with 2^merkleDepthLimit streams at the leaf nodes of the merkle tree.
     // But we don't want to look at *every* pending request just to make sure we can fill our batch,
-    // so we limit ourselves to processing 10x more requests than the number of streams we ultimately
+    // so we limit ourselves to processing twice as many requests as the number of streams we ultimately
     // want to anchor.  If we don't find enough unique streams in all those requests, then we wind
     // up with an under-full batch, but that's okay.
     const streamLimit = Math.pow(2, this.config.merkleDepthLimit)
-    const requestLimit = 10 * streamLimit
+    const requestLimit = 2 * streamLimit
     const requests: Request[] = await this.requestRepository.findNextToProcess(requestLimit)
     await this._anchorRequests(requests)
   }

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -427,13 +427,8 @@ export default class AnchorService {
     }
 
     if (unprocessedRequests.length > 0) {
-      logger.debug(`Returning ${unprocessedRequests.length} unprocessed requests to PENDING status`)
-      await this.requestRepository.updateRequests(
-        {
-          status: RS.PENDING,
-          message: 'Request returned to pending.',
-        },
-        unprocessedRequests
+      logger.debug(
+        `There were ${unprocessedRequests.length} unprocessed requests that didn't make it into this batch.  Leaving them in PENDING state as they were.`
       )
     }
 


### PR DESCRIPTION
Currently the CAS anchor process starts by loading *every* pending request from the DB into memory, and marking all of them as PROCESSING.  Then it works to build a batch out of 2^merkleDepthLimit streams (which is usually 10, so 1024 streams).  Whatever requests it doesn't wind up selecting in the batch wind up getting returned to PENDING.

This patch makes 2 changes:
* first, it limits the number of requests from the DB pulled into memory to twice the number of streams we want based on the merkleDepthLimit.  In practice this will be a max of 2048k requests that we'll consider for any given batch.  If those 2048 requests don't turn out to include 1024 unique, loadable streams, then we proceed with an under-full batch, rather than going through the complexity of going back to the database to fetch more requests in an attempt to fill the batch.
* second, it doesn't mark requests as PROCESSING until after we have successfully loaded the corresponding streams from Ceramic and selected those requests for inclusion in the batch.  This has the downside that if we were to try to run two CAS instances at the same time on the same database, now we would wind up processing the same requests in each instance.  But since we already avoid running multiple CAS instances at once, this is deemed acceptable for now to simplify the logic and prevent us from moving a whole bunch of requests in to PROCESSING only to be sent back to PENDING shortly thereafter if they don't make it into the batch.