### PR TITLE
feat: send prod hanging messages to alerts

### DIFF
--- a/runner/check-aws-ecs-tasks.js
+++ b/runner/check-aws-ecs-tasks.js
@@ -27,7 +27,11 @@ function sendNotification(taskArns) {
   ]
   const data = { embeds: message, username: 'cas-runner' }
   const retryDelayMs = 300000 // 300k ms = 5 mins
-  sendDiscordNotification(process.env.DISCORD_WEBHOOK_URL_WARNINGS, data, retryDelayMs)
+  if (process.env.AWS_ECS_CLUSTER.includes('prod')) {
+    sendDiscordNotification(process.env.DISCORD_WEBHOOK_URL_ALERTS, data, retryDelayMs)
+  } else {
+    sendDiscordNotification(process.env.DISCORD_WEBHOOK_URL_WARNINGS, data, retryDelayMs)
+  }
 }
 
 main()


### PR DESCRIPTION
## Description

Sends CAS hanging alerts to alerts-ceramic Discord channel instead of the warnings channel when in prod environment.

## How Has This Been Tested?

Test in prod!

## References:

https://app.zenhub.com/workspaces/platform-611996cb76d3b50013bfb993/issues/3box/ceramic-infra/480
