### PR TITLE
feat: send discord messages on start and exit

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -8,8 +8,11 @@ if [[ ${STATUS[0]} == "OK" ]]; then
   cd $CAS_PATH && npm run start
   exit_code=$?
   if [[ $exit_code != 0 ]]; then
-    cd $HOME && cd .. && node ./runner/report-exit.js
+    cd $HOME && cd .. && node ./runner/report-failure.js
     echo "CAS exited with non-zero exit code"
+  else
+    cd $HOME && cd .. && node ./runner/report-exit.js
+    echo "CAS exited cleanly"
   fi
 fi
 

--- a/runner/check-aws-ecs-tasks.js
+++ b/runner/check-aws-ecs-tasks.js
@@ -13,6 +13,8 @@ async function main() {
     console.log('OK')
     console.log('Only one running task found (assumed to be self)')
     if (process.env.AWS_ECS_CLUSTER.includes('prod')) {
+      // Only do this in prod because it's too noisy given the short interval of
+      // tnet and dev anchoring
       sendStartNotification(taskArns)
     }
   }

--- a/runner/report-exit.js
+++ b/runner/report-exit.js
@@ -1,18 +1,22 @@
 const { generateDiscordCloudwatchFields, sendDiscordNotification, listECSTasks } = require('./helpers')
 
 async function main() {
-  const taskArns = await listECSTasks()
-  const fields = generateDiscordCloudwatchFields(taskArns)
-  const message = [
-    {
-      title: `CAS anchor task finished (${process.env.AWS_ECS_CLUSTER})`,
-      color: 3447003, // Blue
-      fields,
-    },
-  ]
-  const data = { embeds: message, username: 'cas-runner' }
-  const retryDelayMs = 300000 // 300k ms = 5 mins
-  sendDiscordNotification(process.env.DISCORD_WEBHOOK_URL_INFO_CAS, data, retryDelayMs)
+  if (process.env.AWS_ECS_CLUSTER.includes('prod')) {
+    // Only do this in prod because it's too noisy given the short interval of
+    // tnet and dev anchoring
+    const taskArns = await listECSTasks()
+    const fields = generateDiscordCloudwatchFields(taskArns)
+    const message = [
+        {
+        title: `CAS anchor task finished (${process.env.AWS_ECS_CLUSTER})`,
+        color: 3447003, // Blue
+        fields,
+        },
+    ]
+    const data = { embeds: message, username: 'cas-runner' }
+    const retryDelayMs = 300000 // 300k ms = 5 mins
+    sendDiscordNotification(process.env.DISCORD_WEBHOOK_URL_INFO_CAS, data, retryDelayMs)
+  }
 }
 
 main()

--- a/runner/report-failure.js
+++ b/runner/report-failure.js
@@ -5,14 +5,14 @@ async function main() {
   const fields = generateDiscordCloudwatchFields(taskArns)
   const message = [
     {
-      title: `CAS anchor task finished (${process.env.AWS_ECS_CLUSTER})`,
-      color: 3447003, // Blue
+      title: `CAS failed (${process.env.AWS_ECS_CLUSTER})`,
+      color: 16711712,
       fields,
     },
   ]
   const data = { embeds: message, username: 'cas-runner' }
   const retryDelayMs = 300000 // 300k ms = 5 mins
-  sendDiscordNotification(process.env.DISCORD_WEBHOOK_URL_INFO_CAS, data, retryDelayMs)
+  sendDiscordNotification(process.env.DISCORD_WEBHOOK_URL_ALERTS, data, retryDelayMs)
 }
 
 main()

--- a/runner/report-failure.js
+++ b/runner/report-failure.js
@@ -6,7 +6,7 @@ async function main() {
   const message = [
     {
       title: `CAS failed (${process.env.AWS_ECS_CLUSTER})`,
-      color: 16711712,
+      color: 16711712, // Red
       fields,
     },
   ]


### PR DESCRIPTION
# Discord messages on start and exit

## Description

When in the prod environment, send a message to discord when a CAS anchor task starts and ends

## How Has This Been Tested?

Test in prod!