### PR TITLE
chore: Consider all pending requests in each batch

### DIFF
--- a/src/repositories/request-repository.ts
+++ b/src/repositories/request-repository.ts
@@ -93,11 +93,11 @@ export default class RequestRepository extends Repository<Request> {
   /**
    * Gets all requests by status
    */
-  public async findNextToProcess(limit: number): Promise<Request[]> {
+  public async findNextToProcess(limit?: number): Promise<Request[]> {
     const now: number = new Date().getTime()
     const deadlineDate = new Date(now - this.config.expirationPeriod)
 
-    return await this.connection
+    const queryBuilder = this.connection
       .getRepository(Request)
       .createQueryBuilder('request')
       .orderBy('request.created_at', 'ASC')
@@ -106,8 +106,11 @@ export default class RequestRepository extends Repository<Request> {
         processingStatus: RequestStatus.PROCESSING,
         deadlineDate: deadlineDate.toISOString(),
       })
-      .limit(limit)
-      .getMany()
+    if (limit) {
+      queryBuilder.limit(limit)
+    }
+
+    return queryBuilder.getMany()
   }
 
   /**

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -97,16 +97,9 @@ export default class AnchorService {
    * Creates anchors for client requests
    */
   public async anchorRequests(): Promise<void> {
-    logger.imp('Anchoring pending requests...')
-    // We try to fill our batch with 2^merkleDepthLimit streams at the leaf nodes of the merkle tree.
-    // But we don't want to look at *every* pending request just to make sure we can fill our batch,
-    // so we limit ourselves to processing 3x as many requests as the number of streams we ultimately
-    // want to anchor.  If we don't find enough unique streams in all those requests, then we wind
-    // up with an under-full batch, but that's okay.
-    const streamLimit = Math.pow(2, this.config.merkleDepthLimit)
-    const requestLimit = 3 * streamLimit
+    logger.imp('Anchor batch beginning...')
     logger.debug(`Loading requests from the database`)
-    const requests: Request[] = await this.requestRepository.findNextToProcess(requestLimit)
+    const requests: Request[] = await this.requestRepository.findNextToProcess()
     await this._anchorRequests(requests)
   }
 


### PR DESCRIPTION
loading requests from the database and grouping them by streamid currently takes less than a second. Rather than bothering figuring out the SQL to get just the specific requests we need, we can just pull literally every request from the db and consider them all