### PR TITLE
chore: Do not log every single request ID in batch summary message

### DIFF
--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -158,7 +158,6 @@ export default class AnchorService {
     logger.imp(`Service successfully anchored ${anchors.length} CIDs.`)
     logEvent.anchor({
       type: 'anchorRequests',
-      requestIds: requests.map((r) => r.id),
       acceptedRequestsCount: groupedRequests.acceptedRequests.length,
       alreadyAnchoredRequestsCount: groupedRequests.alreadyAnchoredRequests.length,
       anchoredRequestsCount: numAnchoredRequests,
@@ -599,7 +598,7 @@ export default class AnchorService {
 
     for (const req of missingRequests) {
       console.debug(
-        `Commit CID ${req.cid} is missing from stream ${req.streamId}. Sending multiquery to force ceramic to load it`
+        `Stream ${req.streamId} is missing Commit CID ${req.cid}. Sending multiquery to force ceramic to load it`
       )
     }
 


### PR DESCRIPTION
It's overly verbose, and now that we pull in all pending requests, the log line has gotten so long it seems to have passed some maximum in Log Insights - Log insights is breaking the line up into multiple lines, which is breaking some of the saved queries we use to get reports on what the batch did