### PR TITLE
fix: Sleep one minute at startup for ipfs to stabilize

### DIFF
--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -98,8 +98,11 @@ export default class AnchorService {
    */
   public async anchorRequests(): Promise<void> {
     // TODO: Remove this after restart loop removed as part of switching to go-ipfs
-    logger.imp('sleeping one minute for ipfs to stabilize')
-    await Utils.delay(1000 * 60)
+    // Skip sleep for unit tests
+    if (process.env.NODE_ENV != 'test') {
+      logger.imp('sleeping one minute for ipfs to stabilize')
+      await Utils.delay(1000 * 60)
+    }
 
     logger.imp('Anchoring pending requests...')
     // We try to fill our batch with 2^merkleDepthLimit streams at the leaf nodes of the merkle tree.

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -97,6 +97,10 @@ export default class AnchorService {
    * Creates anchors for client requests
    */
   public async anchorRequests(): Promise<void> {
+    // TODO: Remove this after restart loop removed as part of switching to go-ipfs
+    logger.imp('sleeping one minute for ipfs to stabilize')
+    await Utils.delay(1000 * 60)
+
     logger.imp('Anchoring pending requests...')
     // We try to fill our batch with 2^merkleDepthLimit streams at the leaf nodes of the merkle tree.
     // To make sure we find enough requests on unique streamids to fill the batch, we pull in 100x


### PR DESCRIPTION
Many anchor batches fail to load the first one or two streams at the beginning of the batch with an error like
```
`Failed to load stream k2t6wyfsu4pg0eat56bbz0hb2uk4w1oogh24munj6wsnfqaymyzv6k5akske13: Error: HTTP request to 'https://ceramic-private-cpc.3boxlabs.com/api/v0/streams/k2t6wyfsu4pg0eat56bbz0hb2uk4w1oogh24munj6wsnfqaymyzv6k5akske13?pin=true&sync=0' failed with status 'Internal Server Error': {
    "error": "Request timed out"
}`
```

My suspicion is that the recently-restarted ipfs/ceramic nodes haven't fully stabilized after startup yet, due to the tight restart loop we have in place.  My hope is that giving an extra minute before contacting ceramic/ipfs at the beginning of a batch will eliminate these failed requests.