### PR TITLE
fix: remove anchor delay for dev

### DIFF
--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -141,13 +141,15 @@ export default class AnchorService {
       streamCountLimit,
       minStreamCount
     )
-    if (candidates.length === 0 && process.env.NODE_ENV !== 'dev') {
+    if (candidates.length === 0) {
       logger.imp('No candidates found. Skipping anchor.')
-      logger.debug(
-        'Sleeping 10 minutes before shutting down to prevent constantly running empty anchor batches'
-      )
-      await Utils.delay(1000 * 60 * 10)
-      logger.debug(`Sleep complete, shutting down`)
+      if (process.env.NODE_ENV !== 'dev') {
+        logger.debug(
+            'Sleeping 10 minutes before shutting down to prevent constantly running empty anchor batches'
+        )
+        await Utils.delay(1000 * 60 * 10)
+        logger.debug(`Sleep complete, shutting down`)
+      }
       return
     }
 

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -141,7 +141,7 @@ export default class AnchorService {
       streamCountLimit,
       minStreamCount
     )
-    if (candidates.length === 0) {
+    if (candidates.length === 0 && process.env.NODE_ENV !== 'dev') {
       logger.imp('No candidates found. Skipping anchor.')
       logger.debug(
         'Sleeping 10 minutes before shutting down to prevent constantly running empty anchor batches'


### PR DESCRIPTION
# Remove anchor delay for dev

## Description

Don't sleep for 10 minutes when anchoring on dev.

## Notes
- Requires anchor task definition on infra to have `NODE_ENV` set to `dev`
- Should remove the sleep entirely and keep the control of when anchors occur outside of the CAS source code