### PR TITLE
chore: Pin bloom-filters package to version 1.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22619,6 +22619,14 @@
             "node-fetch": "npm:@achingbrain/node-fetch@^2.6.4",
             "react-native-fetch-api": "^1.0.2",
             "stream-to-it": "^0.2.2"
+          },
+          "dependencies": {
+            "node-fetch": {
+              "version": "npm:@achingbrain/node-fetch@2.6.7",
+              "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+              "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
+              "dev": true
+            }
           }
         },
         "iso-url": {
@@ -22675,8 +22683,7 @@
         "node-fetch": {
           "version": "npm:node-fetch@2.6.7",
           "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
-          "dev": true
+          "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g=="
         }
       }
     },
@@ -23003,6 +23010,14 @@
             "node-fetch": "npm:@achingbrain/node-fetch@^2.6.4",
             "react-native-fetch-api": "^1.0.2",
             "stream-to-it": "^0.2.2"
+          },
+          "dependencies": {
+            "node-fetch": {
+              "version": "npm:@achingbrain/node-fetch@2.6.7",
+              "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+              "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
+              "dev": true
+            }
           }
         },
         "ipld-dag-cbor": {
@@ -23140,8 +23155,7 @@
         "node-fetch": {
           "version": "npm:node-fetch@2.6.7",
           "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
-          "dev": true
+          "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g=="
         },
         "parse-duration": {
           "version": "1.0.0",
@@ -23237,6 +23251,14 @@
             "node-fetch": "npm:@achingbrain/node-fetch@^2.6.4",
             "react-native-fetch-api": "^1.0.2",
             "stream-to-it": "^0.2.2"
+          },
+          "dependencies": {
+            "node-fetch": {
+              "version": "npm:@achingbrain/node-fetch@2.6.7",
+              "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+              "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
+              "dev": true
+            }
           }
         },
         "iso-url": {
@@ -23317,8 +23339,7 @@
         "node-fetch": {
           "version": "npm:node-fetch@2.6.7",
           "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
-          "dev": true
+          "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g=="
         },
         "parse-duration": {
           "version": "1.0.0",
@@ -28970,6 +28991,14 @@
             "node-fetch": "npm:@achingbrain/node-fetch@^2.6.4",
             "react-native-fetch-api": "^1.0.2",
             "stream-to-it": "^0.2.2"
+          },
+          "dependencies": {
+            "node-fetch": {
+              "version": "npm:@achingbrain/node-fetch@2.6.7",
+              "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+              "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
+              "dev": true
+            }
           }
         },
         "iso-url": {
@@ -29047,8 +29076,7 @@
         "node-fetch": {
           "version": "npm:node-fetch@2.6.7",
           "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
-          "dev": true
+          "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g=="
         },
         "streaming-iterables": {
           "version": "6.0.0",
@@ -29119,6 +29147,14 @@
             "node-fetch": "npm:@achingbrain/node-fetch@^2.6.4",
             "react-native-fetch-api": "^1.0.2",
             "stream-to-it": "^0.2.2"
+          },
+          "dependencies": {
+            "node-fetch": {
+              "version": "npm:@achingbrain/node-fetch@2.6.7",
+              "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+              "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
+              "dev": true
+            }
           }
         },
         "iso-url": {
@@ -29205,8 +29241,7 @@
         "node-fetch": {
           "version": "npm:node-fetch@2.6.7",
           "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
-          "dev": true
+          "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g=="
         },
         "p-timeout": {
           "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@ceramicnetwork/streamid": "^1.3.5",
     "@overnightjs/core": "^1.7.5",
     "aws-cron-parser": "1.1.10",
-    "bloom-filters": "^1.3.1",
+    "bloom-filters": "1.3.4",
     "cors": "^2.8.5",
     "dag-jose": "^0.3.0",
     "dotenv": "^8.2.0",


### PR DESCRIPTION
I'm not actually sure why npm seems to be installing version 1.3.4 of this package currently instead of the most recent 1.3.9.

Whatever the reason, it saved us as version 1.3.7 introduced a breaking change to the bloom filter data format.

For now, let's pin to version 1.3.4 so we make sure we don't accidentally start using the newer version of the bloom-filters pacakge until after https://github.com/ceramicnetwork/ceramic-anchor-service/issues/566 is complete, which will enable us to upgrade as we'll be able to keep track of which version was used for each filter we create