### PR TITLE
feat: new ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   # Dagger
   DAGGER_CI: cue.mod/pkg/github.com/3box/pipeline-tools/ci/main.cue
   DAGGER_VERSION: "0.2.15"
-  PIPELINE_TOOLS_VER: "0.1.1"
+  PIPELINE_TOOLS_VER: "0.1.3"
   COMPONENT: "cas"
   # Secrets
   AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   # Dagger
   DAGGER_CI: cue.mod/pkg/github.com/3box/pipeline-tools/ci/main.cue
   DAGGER_VERSION: "0.2.15"
-  PIPELINE_TOOLS_VER: "develop"
+  PIPELINE_TOOLS_VER: "0.1.1"
   COMPONENT: "cas"
   # Secrets
   AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
@@ -22,7 +22,7 @@ env:
 
 jobs:
   push:
-    name: Build and push
+    name: Test and push image
     runs-on: ubuntu-latest
     steps:
       -
@@ -36,5 +36,5 @@ jobs:
           cmds: |
             project init
             project update
-            project update github.com/3box/pipeline-tools@${{ env.PIPELINE_TOOLS_VER }}
+            project update "github.com/3box/pipeline-tools@$v{{ env.PIPELINE_TOOLS_VER }}"
             do build -p ${{ env.DAGGER_CI }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,5 @@ jobs:
           cmds: |
             project init
             project update
-            project update "github.com/3box/pipeline-tools@$v{{ env.PIPELINE_TOOLS_VER }}"
+            project update "github.com/3box/pipeline-tools@v${{ env.PIPELINE_TOOLS_VER }}"
             do build -p ${{ env.DAGGER_CI }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   # Dagger
   DAGGER_CI: cue.mod/pkg/github.com/3box/pipeline-tools/ci/main.cue
   DAGGER_VERSION: "0.2.15"
-  PIPELINE_TOOLS_VER: "0.1.4"
+  PIPELINE_TOOLS_VER: "develop"
   COMPONENT: "cas"
   # Secrets
   AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Test and publish Docker images
 
 on:
   push:
-    branches: [ feat/new-ci, develop, release-candidate, main ]
+    branches: [ develop, release-candidate, main ]
   pull_request: # pull requests
   workflow_dispatch: # manually triggered
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   # Dagger
   DAGGER_CI: cue.mod/pkg/github.com/3box/pipeline-tools/ci/main.cue
   DAGGER_VERSION: "0.2.15"
-  PIPELINE_TOOLS_VER: "0.1.3"
+  PIPELINE_TOOLS_VER: "0.1.4"
   COMPONENT: "cas"
   # Secrets
   AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   # Dagger
   DAGGER_CI: cue.mod/pkg/github.com/3box/pipeline-tools/ci/main.cue
   DAGGER_VERSION: "0.2.15"
-  PIPELINE_TOOLS_VER: "0.1.0-alpha"
+  #PIPELINE_TOOLS_VER: "0.1.0-alpha"
   COMPONENT: "cas"
   # Secrets
   AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,14 @@ name: Test and publish Docker images
 
 on:
   push:
-    branches: [ develop, release-candidate, main ]
+    branches: [ feat/new-ci, develop, release-candidate, main ]
   pull_request: # pull requests
   workflow_dispatch: # manually triggered
 
 env:
   # Dagger
-  DAGGER_LOG_FORMAT: plain
-  DAGGER_LOG_LEVEL: info
-  DAGGER_CACHE_BASE: cas-ci
   DAGGER_CI: cue.mod/pkg/github.com/3box/pipelinetools/ci/main.cue
-  REPO_TYPE: "cas"
+  COMPONENT: "cas"
   # Secrets
   AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -36,32 +33,14 @@ jobs:
         name: Checkout code
         uses: actions/checkout@v3
       -
-        name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v1
-      -
-        name: Set up cache for mainline branches
-        run: |
-          echo "DAGGER_CACHE_TO=type=gha,mode=max,scope=${{ env.DAGGER_CACHE_BASE }}-main" >> $GITHUB_ENV
-          echo "DAGGER_CACHE_FROM=type=gha,scope=${{ env.DAGGER_CACHE_BASE }}-main" >> $GITHUB_ENV
-      -
-        name: Set up cache for for pull requests
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          echo "DAGGER_CACHE_TO=type=gha,mode=max,scope=${{ env.DAGGER_CACHE_BASE }}-${{ github.event.number }}" >> $GITHUB_ENV
-          echo "DAGGER_CACHE_FROM=type=gha,scope=${{ env.DAGGER_CACHE_BASE }}-main type=gha,scope=${{ env.DAGGER_CACHE_BASE }}-${{ github.event.number }}" >> $GITHUB_ENV
-      -
         # Pull the latest pipelinetools.
         # TODO: Once the code is stable, use a tagged version.
         name: Run CI pipeline
         uses: dagger/dagger-for-github@v3
         with:
-          version: "v0.2.12"
+          version: "v0.2.13"
           cmds: |
             project init
             project update
             project update github.com/3box/pipelinetools@develop
             do build -p ${{ env.DAGGER_CI }}
-      -
-        name: Print Buildkitd Logs
-        if: ${{ failure() }}
-        run: docker logs dagger-buildkitd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 env:
   # Dagger
   DAGGER_CI: cue.mod/pkg/github.com/3box/pipeline-tools/ci/main.cue
+  DAGGER_VERSION: "0.2.15"
+  PIPELINE_TOOLS_VER: "develop"
   COMPONENT: "cas"
   # Secrets
   AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
@@ -27,14 +29,12 @@ jobs:
         name: Checkout code
         uses: actions/checkout@v3
       -
-        # Pull the latest pipeline-tools.
-        # TODO: Once the code is stable, use a tagged version.
         name: Run CI pipeline
         uses: dagger/dagger-for-github@v3
         with:
-          version: "v0.2.13"
+          version: ${{ env.DAGGER_VERSION }}
           cmds: |
             project init
             project update
-            project update github.com/3box/pipeline-tools@develop
+            project update github.com/3box/pipeline-tools@${{ env.PIPELINE_TOOLS_VER }}
             do build -p ${{ env.DAGGER_CI }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,14 @@ env:
   # Dagger
   DAGGER_LOG_FORMAT: plain
   DAGGER_LOG_LEVEL: info
-  DAGGER_CACHE_BASE: ceramic-anchor-service-ci
-  DAGGER_CI: cue.mod/pkg/github.com/3box/pipelinetools/ci/ceramic-anchor-service.cue
-  # General
-  BRANCH: ${{ github.ref_name }}
-  GITHUB_SHA: ${{ github.sha }}
+  DAGGER_CACHE_BASE: cas-ci
+  DAGGER_CI: cue.mod/pkg/github.com/3box/pipelinetools/ci/main.cue
+  REPO_TYPE: "cas"
   # Secrets
   AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+  AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
   DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
   DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
@@ -38,60 +36,31 @@ jobs:
         name: Checkout code
         uses: actions/checkout@v3
       -
-        name: Set main branch tag
-        if: ${{ env.BRANCH == 'main' }}
-        run: |
-          echo "ENV_TAG=prod" >> $GITHUB_ENV
-      -
-        name: Set rc branch tag
-        if: ${{ env.BRANCH == 'release-candidate' }}
-        run: |
-          echo "ENV_TAG=tnet" >> $GITHUB_ENV
-      -
-        name: Set develop branch tag
-        if: ${{ env.BRANCH == 'develop' || env.ENV_TAG == '' }}
-        run: |
-          echo "ENV_TAG=dev" >> $GITHUB_ENV
-      -
         name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v1
       -
         name: Set up cache for mainline branches
         run: |
-          echo "DAGGER_CACHE_TO=type=gha,mode=max,scope=${{ env.DAGGER_CACHE_BASE }}-${{ env.ENV_TAG }}" >> $GITHUB_ENV
-          echo "DAGGER_CACHE_FROM=type=gha,scope=${{ env.DAGGER_CACHE_BASE }}-${{ env.ENV_TAG }}" >> $GITHUB_ENV
+          echo "DAGGER_CACHE_TO=type=gha,mode=max,scope=${{ env.DAGGER_CACHE_BASE }}-main" >> $GITHUB_ENV
+          echo "DAGGER_CACHE_FROM=type=gha,scope=${{ env.DAGGER_CACHE_BASE }}-main" >> $GITHUB_ENV
       -
-        name: Set env vars on pull request
+        name: Set up cache for for pull requests
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           echo "DAGGER_CACHE_TO=type=gha,mode=max,scope=${{ env.DAGGER_CACHE_BASE }}-${{ github.event.number }}" >> $GITHUB_ENV
-          echo "DAGGER_CACHE_FROM=type=gha,scope=${{ env.DAGGER_CACHE_BASE }}-${{ env.ENV_TAG }} type=gha,scope=${{ env.DAGGER_CACHE_BASE }}-${{ github.event.number }}" >> $GITHUB_ENV
+          echo "DAGGER_CACHE_FROM=type=gha,scope=${{ env.DAGGER_CACHE_BASE }}-main type=gha,scope=${{ env.DAGGER_CACHE_BASE }}-${{ github.event.number }}" >> $GITHUB_ENV
       -
-        name: Install Dagger
+        # Pull the latest pipelinetools.
+        # TODO: Once the code is stable, use a tagged version.
+        name: Run CI pipeline
         uses: dagger/dagger-for-github@v3
         with:
-          version: "v0.2.11"
-          install-only: true
-      -
-        name: Run unit tests
-        run: |
-          dagger project init
-          dagger project update
-          dagger project update github.com/3box/pipelinetools@develop
-
-          REPO_META=$(dagger do --output-format json build -p ${{ env.DAGGER_CI }})
-          echo "SHA=$(echo "${REPO_META}" | jq -r '.sha')" >> $GITHUB_ENV
-          echo "SHA_TAG=$(echo "${REPO_META}" | jq -r '.shaTag')" >> $GITHUB_ENV
-          echo "BRANCH=$(echo "${REPO_META}" | jq -r '.branch')" >> $GITHUB_ENV
-      -
-        name: Build and test image
-        run: |
-          dagger do verify -p ${{ env.DAGGER_CI }}
-      -
-        name: Push images for mainline branches
-        if: ${{ github.event_name != 'pull_request' }}
-        run: |
-          dagger do -l error push -w "actions:push:\"${{ env.ENV_TAG }}\":tags:[\"${{ env.SHA }}\",\"${{ env.SHA_TAG }}\",\"${{ env.BRANCH }}\",\"${{ env.ENV_TAG }}\"]" -p ${{ env.DAGGER_CI }}
+          version: "v0.2.12"
+          cmds: |
+            project init
+            project update
+            project update github.com/3box/pipelinetools@develop
+            do build -p ${{ env.DAGGER_CI }}
       -
         name: Print Buildkitd Logs
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Dagger
-  DAGGER_CI: cue.mod/pkg/github.com/3box/pipelinetools/ci/main.cue
+  DAGGER_CI: cue.mod/pkg/github.com/3box/pipeline-tools/ci/main.cue
   COMPONENT: "cas"
   # Secrets
   AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
@@ -24,16 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Dump github context
-        run: echo "$GITHUB_CONTEXT"
-        shell: bash
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-      -
         name: Checkout code
         uses: actions/checkout@v3
       -
-        # Pull the latest pipelinetools.
+        # Pull the latest pipeline-tools.
         # TODO: Once the code is stable, use a tagged version.
         name: Run CI pipeline
         uses: dagger/dagger-for-github@v3
@@ -42,5 +36,5 @@ jobs:
           cmds: |
             project init
             project update
-            project update github.com/3box/pipelinetools@develop
+            project update github.com/3box/pipeline-tools@develop
             do build -p ${{ env.DAGGER_CI }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,98 @@
+name: Test and publish Docker images
+
+on:
+  push:
+    branches: [ develop, release-candidate, main ]
+  pull_request: # pull requests
+  workflow_dispatch: # manually triggered
+
+env:
+  # Dagger
+  DAGGER_LOG_FORMAT: plain
+  DAGGER_LOG_LEVEL: info
+  DAGGER_CACHE_BASE: ceramic-anchor-service-ci
+  DAGGER_CI: cue.mod/pkg/github.com/3box/pipelinetools/ci/ceramic-anchor-service.cue
+  # General
+  BRANCH: ${{ github.ref_name }}
+  GITHUB_SHA: ${{ github.sha }}
+  # Secrets
+  AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+jobs:
+  push:
+    name: Build and push
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Dump github context
+        run: echo "$GITHUB_CONTEXT"
+        shell: bash
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+      -
+        name: Checkout code
+        uses: actions/checkout@v3
+      -
+        name: Set main branch tag
+        if: ${{ env.BRANCH == 'main' }}
+        run: |
+          echo "ENV_TAG=prod" >> $GITHUB_ENV
+      -
+        name: Set rc branch tag
+        if: ${{ env.BRANCH == 'release-candidate' }}
+        run: |
+          echo "ENV_TAG=tnet" >> $GITHUB_ENV
+      -
+        name: Set develop branch tag
+        if: ${{ env.BRANCH == 'develop' || env.ENV_TAG == '' }}
+        run: |
+          echo "ENV_TAG=dev" >> $GITHUB_ENV
+      -
+        name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v1
+      -
+        name: Set up cache for mainline branches
+        run: |
+          echo "DAGGER_CACHE_TO=type=gha,mode=max,scope=${{ env.DAGGER_CACHE_BASE }}-${{ env.ENV_TAG }}" >> $GITHUB_ENV
+          echo "DAGGER_CACHE_FROM=type=gha,scope=${{ env.DAGGER_CACHE_BASE }}-${{ env.ENV_TAG }}" >> $GITHUB_ENV
+      -
+        name: Set env vars on pull request
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          echo "DAGGER_CACHE_TO=type=gha,mode=max,scope=${{ env.DAGGER_CACHE_BASE }}-${{ github.event.number }}" >> $GITHUB_ENV
+          echo "DAGGER_CACHE_FROM=type=gha,scope=${{ env.DAGGER_CACHE_BASE }}-${{ env.ENV_TAG }} type=gha,scope=${{ env.DAGGER_CACHE_BASE }}-${{ github.event.number }}" >> $GITHUB_ENV
+      -
+        name: Install Dagger
+        uses: dagger/dagger-for-github@v3
+        with:
+          version: "v0.2.11"
+          install-only: true
+      -
+        name: Run unit tests
+        run: |
+          dagger project init
+          dagger project update
+          dagger project update github.com/3box/pipelinetools@develop
+
+          REPO_META=$(dagger do --output-format json build -p ${{ env.DAGGER_CI }})
+          echo "SHA=$(echo "${REPO_META}" | jq -r '.sha')" >> $GITHUB_ENV
+          echo "SHA_TAG=$(echo "${REPO_META}" | jq -r '.shaTag')" >> $GITHUB_ENV
+          echo "BRANCH=$(echo "${REPO_META}" | jq -r '.branch')" >> $GITHUB_ENV
+      -
+        name: Build and test image
+        run: |
+          dagger do verify -p ${{ env.DAGGER_CI }}
+      -
+        name: Push images for mainline branches
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          dagger do -l error push -w "actions:push:\"${{ env.ENV_TAG }}\":tags:[\"${{ env.SHA }}\",\"${{ env.SHA_TAG }}\",\"${{ env.BRANCH }}\",\"${{ env.ENV_TAG }}\"]" -p ${{ env.DAGGER_CI }}
+      -
+        name: Print Buildkitd Logs
+        if: ${{ failure() }}
+        run: docker logs dagger-buildkitd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   # Dagger
   DAGGER_CI: cue.mod/pkg/github.com/3box/pipeline-tools/ci/main.cue
   DAGGER_VERSION: "0.2.15"
-  PIPELINE_TOOLS_VER: "develop"
+  PIPELINE_TOOLS_VER: "0.1.0-alpha"
   COMPONENT: "cas"
   # Secrets
   AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
@@ -36,5 +36,5 @@ jobs:
           cmds: |
             project init
             project update
-            project update "github.com/3box/pipeline-tools@v${{ env.PIPELINE_TOOLS_VER }}"
+            project update "github.com/3box/pipeline-tools@develop
             do build -p ${{ env.DAGGER_CI }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   # Dagger
   DAGGER_CI: cue.mod/pkg/github.com/3box/pipeline-tools/ci/main.cue
   DAGGER_VERSION: "0.2.15"
-  #PIPELINE_TOOLS_VER: "0.1.0-alpha"
+  PIPELINE_TOOLS_VER: "0.1.0"
   COMPONENT: "cas"
   # Secrets
   AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
@@ -36,5 +36,5 @@ jobs:
           cmds: |
             project init
             project update
-            project update "github.com/3box/pipeline-tools@develop
+            project update "github.com/3box/pipeline-tools@v${{ env.PIPELINE_TOOLS_VER }}"
             do build -p ${{ env.DAGGER_CI }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ data
 .env
 store.db
 logs/
+cue.mod/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ ARG CODE_VERSION="00000"
 
 ENV CODE_VERSION=${CODE_VERSION}
 
-RUN apt-get update && apt-get install -y netcat
-
 WORKDIR /cas
 
 COPY package.json package-lock.json /cas/


### PR DESCRIPTION
This PR implements a new CI pipeline using [Dagger](https://dagger.io/).

This allows the various Ceramic component pipelines to be written entirely agnostically of the pipeline service (e.g. GitHub Workflows).

Dagger is still a little rough around the edges so some of the syntax is non-intuitive. However, as they improve their DX, we'll be able to clean this code up as well.

I've decided to keep the actual pipeline [Dagger plan](https://docs.dagger.io/1202/plan) in a [separate repository](https://github.com/3box/pipelinetools) that can be used from other Ceramic repos instead of scattering the code across the repos.

I have intentionally not deprecated the old pipeline (CircleCI, building an image, posting to Lambda, etc.) until the new one can run correctly end-to-end in parallel.

Tasks accomplished with this PR:

 - [x] Builds the code
 - [x] Runs unit tests
 - [x] Builds the Docker image
 - [x] Start the Docker image and runs a curl request to the healthcheck endpoint.
 - [x] Pushes the image to DockerHub and ECR
 - [x] Queues an event to the job queue