### PR TITLE
Fix: findNextToProcess includes failed

### DIFF
--- a/src/repositories/request-repository.ts
+++ b/src/repositories/request-repository.ts
@@ -17,6 +17,7 @@ import { inject, singleton } from 'tsyringe'
 const ANCHOR_DATA_RETENTION_WINDOW = 1000 * 60 * 60 * 24 * 30 // 30 days
 export const MAX_ANCHORING_DELAY_MS = 1000 * 60 * 60 * 12 //12H
 export const PROCESSING_TIMEOUT = 1000 * 60 * 60 * 6 //6H
+export const FAILURE_RETRY_WINDOW = 1000 * 60 * 60 * 48 // 48H
 
 @singleton()
 @EntityRepository(Request)
@@ -92,11 +93,17 @@ export class RequestRepository extends Repository<Request> {
    * Gets all requests by status
    */
   public async findNextToProcess(limit: number): Promise<Request[]> {
+    const earliestDateToRetry = new Date(Date.now() - FAILURE_RETRY_WINDOW)
+
     return await this.connection
       .getRepository(Request)
       .createQueryBuilder('request')
       .orderBy('request.created_at', 'ASC')
       .where('request.status = :pendingStatus', { pendingStatus: RequestStatus.PENDING })
+      .orWhere('request.status = :failedStatus AND request.createdAt >= :earliestDateToRetry', {
+        failedStatus: RequestStatus.FAILED,
+        earliestDateToRetry: DateUtils.mixedDateToUtcDatetimeString(earliestDateToRetry),
+      })
       .limit(limit)
       .getMany()
   }


### PR DESCRIPTION
Retry failed anchor requests in every subsequent batch up to 48 hours after the request was created. Should help us be more resilient to transient networking errors and reduce the frequency of anchor requests failing entirely (at the risk of anchoring requests out of order, which could break 3IDs, but matters less with did:pkh)