### PR TITLE
Fix: flaky ceramic integration tests

### DIFF
--- a/src/__tests__/ceramic_integration.test.ts
+++ b/src/__tests__/ceramic_integration.test.ts
@@ -150,14 +150,14 @@ async function anchorUpdate(stream: Stream, anchorService: CeramicAnchorApp): Pr
 async function waitForAnchor(stream: Stream, timeoutMS = 30 * 1000): Promise<void> {
   await firstValueFrom(
     stream.pipe(
+      filter((state) => [AnchorStatus.ANCHORED, AnchorStatus.FAILED].includes(state.anchorStatus)),
       timeout({
         each: timeoutMS,
         with: () =>
           throwError(
             () => new Error(`Timeout waiting for stream ${stream.id.toString()} to become anchored`)
           ),
-      }),
-      filter((state) => [AnchorStatus.ANCHORED, AnchorStatus.FAILED].includes(state.anchorStatus))
+      })
     )
   )
 }
@@ -165,6 +165,9 @@ async function waitForAnchor(stream: Stream, timeoutMS = 30 * 1000): Promise<voi
 async function waitForTip(stream: Stream, tip: CID, timeoutMS = 30 * 1000): Promise<void> {
   await firstValueFrom(
     stream.pipe(
+      filter((state) => {
+        return state.log[state.log.length - 1].cid.toString() === tip.toString()
+      }),
       timeout({
         each: timeoutMS,
         with: () =>
@@ -174,9 +177,6 @@ async function waitForTip(stream: Stream, tip: CID, timeoutMS = 30 * 1000): Prom
                 `Timeout waiting for ceramic to receive cid ${tip.toString()} for stream ${stream.id.toString()}`
               )
           ),
-      }),
-      filter((state) => {
-        return state.log[state.log.length - 1].cid.toString() === tip.toString()
       })
     )
   )

--- a/src/__tests__/ceramic_integration.test.ts
+++ b/src/__tests__/ceramic_integration.test.ts
@@ -19,7 +19,7 @@ import { config } from 'node-config-ts'
 import cloneDeep from 'lodash.clonedeep'
 import { TileDocument } from '@ceramicnetwork/stream-tile'
 import { filter, take } from 'rxjs/operators'
-import { firstValueFrom } from 'rxjs'
+import { firstValueFrom, timeout, throwError } from 'rxjs'
 import { DID } from 'dids'
 import { Ed25519Provider } from 'key-did-provider-ed25519'
 import * as sha256 from '@stablelib/sha256'
@@ -154,6 +154,24 @@ async function waitForAnchor(stream: Stream): Promise<void> {
       take(1)
     )
     .toPromise()
+}
+
+async function waitForUpdate(stream: Stream, update: CID, timeoutMS = 30 * 1000): Promise<void> {
+  await firstValueFrom(
+    stream.pipe(
+      filter((state) => {
+        return state.log[state.log.length - 1].cid.toString() === update.toString()
+      }),
+      timeout({
+        each: timeoutMS,
+        with: () =>
+          throwError(
+            () =>
+              new Error(`Timeout waiting for ceramic to receive update cid ${update.toString()}`)
+          ),
+      })
+    )
+  )
 }
 
 describe('Ceramic Integration Test', () => {
@@ -390,13 +408,7 @@ describe('Ceramic Integration Test', () => {
 
         // Make sure that the ceramic CAS has received the newest version
         const casDocRef = await casCeramic1.loadStream(doc1.id)
-        await firstValueFrom(
-          casDocRef.pipe(
-            filter((state) => {
-              return state.next?.content.foo === updatedContent.foo
-            })
-          )
-        )
+        await waitForUpdate(casDocRef, doc2.tip)
 
         // Make sure that cas1 updates the newest version that was created on ceramic2, even though
         // the request that ceramic1 made against cas1 was for an older version.
@@ -438,13 +450,7 @@ describe('Ceramic Integration Test', () => {
 
         // Make sure that the ceramic CAS has received the newest version
         const casDocRef = await casCeramic1.loadStream(doc1.id)
-        await firstValueFrom(
-          casDocRef.pipe(
-            filter((state) => {
-              return state.next?.content.foo === updatedContent.foo
-            })
-          )
-        )
+        await waitForUpdate(casDocRef, doc2.tip)
 
         await anchorUpdate(doc1, cas1)
 

--- a/src/__tests__/ceramic_integration.test.ts
+++ b/src/__tests__/ceramic_integration.test.ts
@@ -429,7 +429,7 @@ describe('Ceramic Integration Test', () => {
       60 * 1000 * 2
     )
 
-    test('Anchor discovered through pubsub', async () => {
+    test.only('Anchor discovered through pubsub', async () => {
       jest.setTimeout(60 * 1000 * 2)
       // In ceramic the stream waits for a successful anchor by polling the request endpoint of the CAS.
       // We alter the CAS' returned request anchor status so that it is always pending.
@@ -465,6 +465,7 @@ describe('Ceramic Integration Test', () => {
         expect(doc1.state.anchorStatus).toEqual(AnchorStatus.ANCHORED)
         expect(doc1.content).toEqual(updatedContent)
 
+        await waitForAnchor(doc2)
         await doc2.sync({ sync: SyncOptions.NEVER_SYNC })
         expect(doc2.state.anchorStatus).toEqual(AnchorStatus.ANCHORED)
         expect(doc2.content).toEqual(updatedContent)

--- a/src/__tests__/ceramic_integration.test.ts
+++ b/src/__tests__/ceramic_integration.test.ts
@@ -429,7 +429,7 @@ describe('Ceramic Integration Test', () => {
       60 * 1000 * 2
     )
 
-    test.only('Anchor discovered through pubsub', async () => {
+    test('Anchor discovered through pubsub', async () => {
       jest.setTimeout(60 * 1000 * 2)
       // In ceramic the stream waits for a successful anchor by polling the request endpoint of the CAS.
       // We alter the CAS' returned request anchor status so that it is always pending.

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -591,6 +591,10 @@ export class AnchorService {
       candidate.failAllRequests()
       return
     }
+    console.log(
+      '🚀 ~ file: anchor-service.ts ~ line 589 ~ AnchorService ~ _loadCandidate ~ stream',
+      stream.content
+    )
 
     // Now filter out requests from the Candidate that are already present in the stream log
     const missingRequests = candidate.requests.filter((req) => {

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -591,10 +591,6 @@ export class AnchorService {
       candidate.failAllRequests()
       return
     }
-    console.log(
-      '🚀 ~ file: anchor-service.ts ~ line 589 ~ AnchorService ~ _loadCandidate ~ stream',
-      stream.content
-    )
 
     // Now filter out requests from the Candidate that are already present in the stream log
     const missingRequests = candidate.requests.filter((req) => {


### PR DESCRIPTION
The "Consensus for anchors" integration tests periodically fail. It seems that the CAS is not anchoring the latest update. My suspicion (could not reproduce locally) is that the CAS ceramic node isn't receiving the latest update before the anchor. So my fix is to wait for the latest update and then anchor. Timing in tests is a very tricky thing. This may not work but we won't really know until we try. 