### PR TITLE
CI/CD integration fixes for the build contacts, and build cas steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,8 +54,8 @@ jobs:
           command: |
             echo $PATH
             ls -lah $HOME/.foundry/bin 
-            sudo npm run installContractDeps
-            sudo npm run buildContract
+            npm run installContractDeps
+            npm run buildContract
 
       - run:
           name: build cas

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,10 @@ jobs:
 
       - run:
           name: build cas
-          command: sudo npm run build
+          command: |
+            node -v
+            ls -lah ./
+            sudo npm run build
 
       - run:
           name: test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ jobs:
           name: build contracts
           command: |
             echo $PATH
+            ls -lah $HOME/.foundry/bin 
             sudo npm run installContractDeps
             sudo npm run buildContract
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,6 @@ jobs:
       - run:
           name: build contracts
           command: |
-            echo $PATH
-            ls -lah $HOME/.foundry/bin 
             npm run installContractDeps
             npm run buildContract
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,10 +57,7 @@ jobs:
 
       - run:
           name: build cas
-          command: |
-            node -v
-            ls -lah ./
-            sudo npm run build
+          command: sudo npm run build --ignore-scripts
 
       - run:
           name: test

--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -9,8 +9,6 @@ DEFAULT_ACCOUNT = 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2
 GAS_LIMIT = 90000000000000000
 SHELL = /bin/bash
 build:
-	whoami
-	ls -lah $HOME/.foundry/bin 
 	forge build
 t:
 	forge test -vvvvv

--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -10,6 +10,7 @@ GAS_LIMIT = 90000000000000000
 SHELL = /bin/bash
 build:
 	forge build
+	ls -lah out/
 t:
 	forge test -vvvvv
 g:

--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -9,6 +9,8 @@ DEFAULT_ACCOUNT = 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2
 GAS_LIMIT = 90000000000000000
 SHELL = /bin/bash
 build:
+	whoami
+	ls -lah $HOME/.foundry/bin 
 	forge build
 t:
 	forge test -vvvvv

--- a/package-lock.json
+++ b/package-lock.json
@@ -22044,7 +22044,6 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -22357,7 +22356,6 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"


### PR DESCRIPTION
This fixes the broken steps of the pipeline for building contracts, and cas

## Description
Small PR to fix issues in our pipeline for building the contracts. The contract building was failing because we were installing the deps as a the ```circleci``` user, but then trying to invoke the NPM script as ```root```. Since we were setting the PATH with $HOME, using ```sudo``` changes that ```$HOME``` directory to like ```/home/root``` etc

```yaml
- run:
   name: install dependencies
   command: |
     curl -L https://foundry.paradigm.xyz | bash ## installing as circleci ##
      echo 'export PATH="$HOME/.foundry/bin:$PATH"' >> /home/circleci/.bashrc
     source /home/circleci/.bashrc
     echo 'export PATH="$HOME/.foundry/bin:$PATH"' >> $BASH_ENV
     source $BASH_ENV
     foundryup
     forge --version
- run:
     name: build contracts
     command: |
     echo $PATH
     sudo npm run installContractDeps ## invoking as root ##
     sudo npm run buildContract  ## invoking as root ##
```

Also, inside the package.json, the preBuild stage is running before the build stage, and because the repo isn't built yet by this step in the runner's environment, the ```"clean": "rm -rf ./build; rm -rf coverage; rm -rf .nyc_output",``` commands were failing since those artifacts didn't exist yet. 

We can use ```--ignore-scripts``` for the ```build cas``` step, since that won't change the actual package script command. We may not need to run ```clean``` on a fresh build in the pipeline, especially if no build artifacts are being pushed, and since they are .gitignored here:

https://github.com/ceramicnetwork/ceramic-anchor-service/blob/develop/.gitignore

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x] Local machine
- [x] CircleCI
