### PR TITLE
correct parameter name for metrics start

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -79,7 +79,8 @@ export class CeramicAnchorApp {
 
     if (config.metrics.exporterEnabled) {
       try {
-        Metrics.start({ port: config.metrics.port, metricsExporterEnabled: true })
+        Metrics.start({ metricsPort: config.metrics.port, metricsExporterEnabled: true })
+        logger.imp("Metrics exporter started")
       } catch (e) {
         logger.err(e)
         // start anchor service even if metrics threw an error


### PR DESCRIPTION
# quick fix to correct parameter name to start metrics exporter

## Description

Ok so probably should have made explicit parameters but this package is used in several places

So just fix and use the correct name in the config object 

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ ] Test A (e.g. Test A - New test that ... ran in local, docker, and dev unstable.)
- [ ] Test B

## Definition of Done

Before submitting this PR, please make sure:

- [ ] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
