### PR TITLE
chore: remove batching from anchor (DO NOT MERGE, NET-1711) 

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -80,7 +80,7 @@ export class CeramicAnchorApp {
     if (config.metrics.exporterEnabled) {
       try {
         Metrics.start({ metricsPort: config.metrics.port, metricsExporterEnabled: true })
-        logger.imp("Metrics exporter started")
+        logger.imp('Metrics exporter started')
       } catch (e) {
         logger.err(e)
         // start anchor service even if metrics threw an error
@@ -134,9 +134,9 @@ export class CeramicAnchorApp {
     )
   }
 
-  public async anchor(triggeredByAnchorEvent = false): Promise<void> {
+  public async anchor(): Promise<void> {
     const anchorService: AnchorService = this.container.resolve<AnchorService>('anchorService')
-    return anchorService.anchorRequests(triggeredByAnchorEvent)
+    return anchorService.anchorRequests()
   }
 
   /**

--- a/src/services/__tests__/anchor-service.test.ts
+++ b/src/services/__tests__/anchor-service.test.ts
@@ -152,8 +152,8 @@ describe('anchor service', () => {
       const request = new Request()
       request.cid = cid.toString()
       request.streamId = streamId.toString()
-      request.status = RequestStatus.PENDING
-      request.message = 'Request is pending.'
+      request.status = RequestStatus.READY
+      request.message = 'Request is ready.'
 
       requests.push(request)
     }

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -80,26 +80,9 @@ export class AnchorService {
   }
 
   /**
-   * Creates anchors for pending client requests
-   */
-  // TODO: Remove for CAS V2 as we won't need to move PENDING requests to ready. Switch to using anchorReadyRequests.
-  public async anchorRequests(triggeredByAnchorEvent = false): Promise<void> {
-    const readyRequests = await this.requestRepository.findByStatus(RS.READY)
-
-    if (!triggeredByAnchorEvent && readyRequests.length === 0) {
-      const maxStreamLimit =
-        this.config.merkleDepthLimit > 0 ? Math.pow(2, this.config.merkleDepthLimit) : 0
-      const minStreamLimit = this.config.minStreamCount || Math.floor(maxStreamLimit / 2)
-      await this.requestRepository.findAndMarkReady(maxStreamLimit, minStreamLimit)
-    }
-
-    return this.anchorReadyRequests()
-  }
-
-  /**
    * Creates anchors for client requests that have been marked as READY
    */
-  public async anchorReadyRequests(): Promise<void> {
+  public async anchorRequests(): Promise<void> {
     // TODO: Remove this after restart loop removed as part of switching to go-ipfs
     // Skip sleep for unit tests
     if (process.env.NODE_ENV != 'test') {


### PR DESCRIPTION
Once scheduler service is up an anchor does not have to batch so will merge this PR once the scheduler service is up and running