### PR TITLE
feat: use bytes32 in smart contract

### DIFF
--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -33,7 +33,7 @@ create:
 invoke:
 	cast call ${CONTRACT_ADDRESS} "${FUNC}" --rpc-url ${ETH_RPC_HOST}:${ETH_RPC_PORT}
 anchor:
-	cast send --private-key ${ETH_WALLET_PK} ${CONTRACT_ADDRESS} "anchor(bytes32)" "0x3078300000000000000000000000000000000000000000000000000000000000" --legacy
+	cast send --private-key ${ETH_WALLET_PK} ${CONTRACT_ADDRESS} "anchorDagCbor(bytes32)" "0x3078300000000000000000000000000000000000000000000000000000000000" --legacy
 installDeps:
 	forge install foundry-rs/forge-std --no-git
 	forge install openzeppelin/openzeppelin-contracts --no-git

--- a/contracts/src/CeramicAnchorServiceV2.sol
+++ b/contracts/src/CeramicAnchorServiceV2.sol
@@ -16,7 +16,7 @@ contract CeramicAnchorServiceV2 is Ownable {
     event DidRemoveCas(address indexed _service);
 
     //upon successful anchor
-    event DidAnchor(address indexed _service, bytes _root);
+    event DidAnchor(address indexed _service, bytes32 _root);
 
     // Only addresses in the allow list is allowed to anchor
     modifier onlyAllowed() {
@@ -65,7 +65,7 @@ contract CeramicAnchorServiceV2 is Ownable {
         @param calldata _root
         @desc Here _root is a byte representation of Merkle root CID.
     */
-    function anchor(bytes calldata _root) public onlyAllowed {
+    function anchorDagCbor(bytes32 _root) public onlyAllowed {
         emit DidAnchor(msg.sender, _root);
     }
     

--- a/contracts/test/CeramicAnchorServiceV2.t.sol
+++ b/contracts/test/CeramicAnchorServiceV2.t.sol
@@ -62,19 +62,19 @@ contract CeramicAnchorServiceV2Test is Test {
     function testAnchor() public {
         address testService = address(this);
         casv2.addCas(testService);
-        casv2.anchor("0x0");
+        casv2.anchorDagCbor("0x0");
     }
 
-    function testAnchorFuzz(bytes calldata _root) public {
+    function testAnchorFuzz(bytes32 _root) public {
         address testService = address(this);
         casv2.addCas(testService);
-        casv2.anchor(_root);
+        casv2.anchorDagCbor(_root);
     }
 
-    function testFailAnchorFuzz(bytes calldata _root, address testService) public {
+    function testFailAnchorFuzz(bytes32 _root, address testService) public {
         vm.expectRevert(stdError.assertionError);
         vm.assume(testService != address(this)); 
         casv2.addCas(testService);
-        casv2.anchor(_root);
+        casv2.anchorDagCbor(_root);
     }
 }

--- a/src/services/blockchain/__tests__/eth-bc-service.test.ts
+++ b/src/services/blockchain/__tests__/eth-bc-service.test.ts
@@ -171,7 +171,7 @@ describe('ETH service connected to ganache', () => {
       expect(tx.blockTimestamp).toBeLessThan(startTimestamp + 5)
       expect(tx.blockNumber).toBe(block.number + 1)
       expect(tx.txHash).toEqual(
-        '0xe6526786001e9eb2247e833ca78c1a2761b0d0de3fa58b9a6b95e40dbb7f3a0a'
+        '0x09d184cd4f62672de91fd5eaa7e7b1bf62ca1c2936281dc37201534b013c8f48'
       )
     })
   })

--- a/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
+++ b/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
@@ -21,7 +21,7 @@ const NUM_BLOCKS_TO_WAIT = 4
 export const MAX_RETRIES = 3
 
 const POLLING_INTERVAL = 15 * 1000 // every 15 seconds
-const ABI = ['function anchor(bytes)']
+const ABI = ['function anchorDagCbor(bytes32)']
 
 class WrongChainIdError extends Error {
   constructor(expected: number, actual: number) {
@@ -278,21 +278,24 @@ export class EthereumBlockchainService implements BlockchainService {
   }
 
   async _buildTransactionRequest(rootCid: CID): Promise<TransactionRequest> {
-    const rootStrHex = rootCid.toString(base16)
-    const hexEncoded = '0x' + (rootStrHex.length % 2 == 0 ? rootStrHex : '0' + rootStrHex)
-    logger.imp(`Hex encoded root CID ${hexEncoded}`)
-
     logger.debug('Preparing ethereum transaction')
     const baseNonce = await this.wallet.provider.getTransactionCount(this.wallet.address)
 
     if (!this.config.useSmartContractAnchors) {
+      const rootStrHex = rootCid.toString(base16)
+      const hexEncoded = '0x' + (rootStrHex.length % 2 == 0 ? rootStrHex : '0' + rootStrHex)
+      logger.imp(`Hex encoded root CID ${hexEncoded}`)
+
       return {
         to: this.wallet.address,
         data: hexEncoded,
         nonce: baseNonce,
       }
     }
-    const transactionRequest = await this._contract.populateTransaction.anchor(hexEncoded)
+
+    const transactionRequest = await this._contract.populateTransaction.anchorDagCbor(
+      rootCid.bytes.slice(4)
+    )
     return {
       to: this.config.blockchain.connectors.ethereum.contractAddress,
       data: transactionRequest.data,

--- a/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
+++ b/src/services/blockchain/ethereum/ethereum-blockchain-service.ts
@@ -3,6 +3,7 @@ import { base16 } from 'multiformats/bases/base16'
 import { ErrorCode } from '@ethersproject/logger'
 import { BigNumber, BigNumberish, Contract, ethers } from 'ethers'
 import { Config } from 'node-config-ts'
+import * as uint8arrays from 'uint8arrays'
 
 import { logger, logEvent, logMetric } from '../../../logger/index.js'
 import { Transaction } from '../../../models/transaction.js'
@@ -293,9 +294,8 @@ export class EthereumBlockchainService implements BlockchainService {
       }
     }
 
-    const transactionRequest = await this._contract.populateTransaction.anchorDagCbor(
-      rootCid.bytes.slice(4)
-    )
+    const hexEncoded = '0x' + uint8arrays.toString(rootCid.bytes.slice(4), 'base16')
+    const transactionRequest = await this._contract.populateTransaction.anchorDagCbor(hexEncoded)
     return {
       to: this.config.blockchain.connectors.ethereum.contractAddress,
       data: transactionRequest.data,


### PR DESCRIPTION
I discard the first 4 bytes of the CID [version, code, hash code, digest size]. This is 2 more bytes than described in the ticket. Please let me know if this is okay.  
