### PR TITLE
fix(runner): log ok to start app

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-export TASK="$(node ./runner/report-start.js)"
-echo $TASK
+export LOGS="$(node ./runner/report-start.js)"
+echo $LOGS
 
-STATUS=($TASK)
-if [[ ${STATUS[0]} == "OK" ]]; then
+LOGS=($LOGS)
+if [[ ${LOGS[0]} == "OK" ]]; then
   cd $CAS_PATH && npm run start
   exit_code=$?
   if [[ $exit_code != 0 ]]; then

--- a/runner/report-start.js
+++ b/runner/report-start.js
@@ -3,6 +3,7 @@ import {
 } from './helpers.js'
 
 async function main() {
+  console.log('OK')
   const messageWithoutFields = [
     {
       title: `CAS anchor task started (${process.env.AWS_ECS_CLUSTER})`,


### PR DESCRIPTION
## Description

Fixes a bug where the app doesn't start because `npm run start` doesn't get called.
This PR adds back the console log which is checked before running the npm script.

## How Has This Been Tested?

Tested locally with docker, was able to repro and see the fix work.