### PR TITLE
Fix/report start to info

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ It sends updates on the start and exit status of the container to Discord webhoo
 docker build . -f Dockerfile.runner -t cas-runner
 ```
 
+```sh
+docker run cas-runner
+```
+
+Test the runner with Discord by using test webhooks instead of the actual alert channels.
+```
+docker run -e DISCORD_WEBHOOK_URL_INFO_CAS="<test_webhook_url>" -e DISCORD_WEBHOOK_URL_ALERTS="<test_webhook_url>" cas-runner
+```
+
 ### Prerequisites
 
 In order to run the simulation you need to install [Node.js](https://nodejs.org).

--- a/runner/helpers.js
+++ b/runner/helpers.js
@@ -15,7 +15,10 @@ function reportTask(messageWithoutFields, reportingLevel = REPORTING_LEVEL.info)
   console.log('Reporting ECS task...')
   const taskArn = getThisTaskArn()
   const fields = generateDiscordCloudwatchFields([taskArn])
-  const message = [{...messageWithoutFields[0], fields}]
+  let message = messageWithoutFields
+  if (fields.length > 1) {
+    message = [{...messageWithoutFields[0], fields}]
+  }
   const data = { embeds: message, username: 'cas-runner' }
   const retryDelayMs = 300000 // 300k ms = 5 mins
   let webhookUrl = process.env.DISCORD_WEBHOOK_URL_INFO_CAS

--- a/runner/helpers.js
+++ b/runner/helpers.js
@@ -49,7 +49,7 @@ function generateDiscordCloudwatchFields(taskArns) {
     if (id) {
       value = `${process.env.CLOUDWATCH_LOG_BASE_URL}${id[0]}`
     }
-    return { name: `Task ${index}`, value }
+    return { name: `Task id`, value }
   })
   return fields
 }

--- a/runner/helpers.js
+++ b/runner/helpers.js
@@ -2,18 +2,27 @@ import child_process from 'child_process'
 import * as https from 'https'
 import { ECSClient, ListTasksCommand } from '@aws-sdk/client-ecs'
 
+const REPORTING_LEVEL = {
+  info: 'info',
+  error: 'error'
+}
+
 /**
  * Sends Discord message about ECS task
  * @param {any} messageWithoutFields
  */
-function reportTask(messageWithoutFields) {
+function reportTask(messageWithoutFields, reportingLevel = REPORTING_LEVEL.info) {
   console.log('Reporting ECS task...')
   const taskArn = getThisTaskArn()
   const fields = generateDiscordCloudwatchFields([taskArn])
   const message = [{...messageWithoutFields[0], fields}]
   const data = { embeds: message, username: 'cas-runner' }
   const retryDelayMs = 300000 // 300k ms = 5 mins
-  sendDiscordNotification(process.env.DISCORD_WEBHOOK_URL_ALERTS, data, retryDelayMs)
+  let webhookUrl = process.env.DISCORD_WEBHOOK_URL_INFO_CAS
+  if (reportingLevel == REPORTING_LEVEL.error) {
+    webhookUrl = process.env.DISCORD_WEBHOOK_URL_ALERTS
+  }
+  sendDiscordNotification(webhookUrl, data, retryDelayMs)
 }
 
 /**
@@ -101,4 +110,4 @@ function sendDiscordNotification(webhookUrl, data, retryDelayMs = -1) {
   req.end()
 }
 
-export { generateDiscordCloudwatchFields, getThisTaskArn, listECSTasks, reportTask, sendDiscordNotification }
+export { REPORTING_LEVEL, generateDiscordCloudwatchFields, getThisTaskArn, listECSTasks, reportTask, sendDiscordNotification }

--- a/runner/report-exit.js
+++ b/runner/report-exit.js
@@ -1,4 +1,5 @@
 import {
+  REPORTING_LEVEL,
   reportTask,
 } from './helpers.js'
 
@@ -9,7 +10,7 @@ async function main() {
       color: 3447003, // Blue
     },
   ]
-  reportTask(messageWithoutFields)
+  reportTask(messageWithoutFields, REPORTING_LEVEL.info)
 }
 
 main()

--- a/runner/report-failure.js
+++ b/runner/report-failure.js
@@ -1,4 +1,5 @@
 import {
+  REPORTING_LEVEL,
   reportTask,
 } from './helpers.js'
 
@@ -9,7 +10,7 @@ async function main() {
       color: 16711712, // Red
     },
   ]
-  reportTask(messageWithoutFields)
+  reportTask(messageWithoutFields, REPORTING_LEVEL.error)
 }
 
 main()

--- a/runner/report-start.js
+++ b/runner/report-start.js
@@ -1,4 +1,5 @@
 import {
+  REPORTING_LEVEL,
   reportTask,
 } from './helpers.js'
 
@@ -9,7 +10,7 @@ async function main() {
       color: 3447003, // Blue
     },
   ]
-  reportTask(messageWithoutFields)
+  reportTask(messageWithoutFields, REPORTING_LEVEL.info)
 }
 
 main()


### PR DESCRIPTION
## Description

Ensures that tasks get reported to the correct discord channel. (i.e. failures -> alerts, everything else -> info)

## How Has This Been Tested?

Tested against a test discord while running the docker image
<img width="316" alt="image" src="https://user-images.githubusercontent.com/8445610/186539495-55ed6b57-16f8-4546-8996-8b444556e0ac.png">
<img width="262" alt="image" src="https://user-images.githubusercontent.com/8445610/186539512-dc808aaf-971d-470e-b94c-ca739e17c31d.png">



