### PR TITLE
Fix Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Ceramic anchor service is a PoC implementation of an anchor service according to
 
 This implementation currently uses the Ethereum blockchain but is built in order to be blockchain agnostic. It is fairly easy to add more modules to support other blockchains as well.  
 
-## Usage
+## Usage (Docker)
+
+### Docker
 
 **Build the CAS image:**
 ```sh
@@ -14,22 +16,31 @@ docker build . -f Dockerfile -t cas
 ```
 
 **Build the runner image (optional):**
+
 The runner is only useful if running CAS with ECS.
 It sends updates on the start and exit status of the container to Discord webhooks.
 ```sh
 # First make sure your CAS image was tagged "cas"
 # then build the runner (a wrapper around CAS)
 docker build . -f Dockerfile.runner -t cas-runner
-```
 
-```sh
 docker run cas-runner
-```
 
-Test the runner with Discord by using test webhooks instead of the actual alert channels.
-```
+# Test the runner with Discord by using test
+# webhooks instead of the actual alert channels.
 docker run -e DISCORD_WEBHOOK_URL_INFO_CAS="<test_webhook_url>" -e DISCORD_WEBHOOK_URL_ALERTS="<test_webhook_url>" cas-runner
 ```
+
+### Docker Compose
+
+Docker compose will run two instances of CAS--the api in "server" mode and the anchor worker in "anchor" mode.
+
+```sh
+docker compose up
+docker compose down
+```
+
+## Usage (Node.js)
 
 ### Prerequisites
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - ETH_OVERRIDE_GAS_CONFIG=false
       - ETH_WALLET_PK=0x16dd0990d19001c50eeea6d32e8fdeef40d3945962caf18c18c3930baa5a6ec9
 
-      - IPFS_API_URL=ipfs:5001
+      - IPFS_API_URL=http://ipfs:5011
       - IPFS_API_TIMEOUT=10000
 
       - LOG_LEVEL=debug
@@ -46,6 +46,7 @@ services:
       - "/usr/local/var/log:/usr/local/var/log"
     depends_on:
       - ipfs
+      - database
     ports:
       - "8081:8081"
     networks:
@@ -58,9 +59,11 @@ services:
       - NODE_ENV=dev
       - APP_MODE=anchor
       - APP_PORT=8081
+
       - ANCHOR_CONTROLLER_ENABLED=false
       - ANCHOR_EXPIRATION_PERIOD=0
       - ANCHOR_SCHEDULE_EXPRESSION=0/1 * * * ? *
+
       - BLOCKCHAIN_CONNECTOR=ethereum
       - CERAMIC_API_URL=http://host.docker.internal:7007
       - ETH_GAS_LIMIT=4712388
@@ -68,8 +71,10 @@ services:
       - ETH_NETWORK=ropsten
       - ETH_OVERRIDE_GAS_CONFIG=false
       - ETH_WALLET_PK=0x16dd0990d19001c50eeea6d32e8fdeef40d3945962caf18c18c3930baa5a6ec9
-      - IPFS_API_URL=ipfs:5001
+
+      - IPFS_API_URL=http://ipfs:5011
       - IPFS_API_TIMEOUT=10000
+
       - LOG_LEVEL=debug
       - LOG_TO_FILES=true
       - LOG_PATH=/usr/local/var/log
@@ -92,17 +97,17 @@ services:
       - "/usr/local/var/log:/usr/local/var/log"
     depends_on:
       - ipfs
+      - database
     networks:
       - internal
 
   ipfs:
     image: ceramicnetwork/ipfs-daemon
-    hostname: ipfs_host
     volumes:
       - "./export:/export"
       - "./data/ipfs:/data/ipfs"
     ports:
-      - "5001:5001"
+      - "5011:5011"
       - "4001:4001"
       - "8080:8080"
     networks:
@@ -161,4 +166,3 @@ services:
 networks:
   internal:
     driver: bridge
-


### PR DESCRIPTION
## Description

This PR fixes docker compose so that CAS properly connects to the IPFS container that gets spun up.
This also fixes our CI which tries to use docker compose to do image verification.

- When ipfs-http-client is used to subscribe to pubsub, it makes an http request to IPFS but expects the uri to start with http or https.
- Also the port used by ceramicnetwork/ipfs-daemon is 5011, not 5001.

## How Has This Been Tested?

Tested locally and was able to repro the issue and see the fix work.

Broken
<img width="901" alt="image" src="https://user-images.githubusercontent.com/8445610/186728467-6cbead11-24f9-42f3-bfc6-3c2c67c0b091.png">

Working
<img width="891" alt="image" src="https://user-images.githubusercontent.com/8445610/186725982-a4b73d82-6c42-4962-81da-38739588c6c5.png">

