### PR TITLE
chore(ci): use sha value `latest` for dagger deploy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         # TODO: Use for all envs once Prod starts using the CD manager.
         name: Create deployment job
         if: ${{ env.BRANCH == 'develop' || env.BRANCH == 'release-candidate' }}
-        run: dagger do -l error deploy -w "actions:deploy:\"${{ env.AWS_REGION }}\":\"${{ env.ENV_TAG }}\":\"${{ env.SHA }}\":\"${{ env.SHA_TAG }}\":_" -p ${{ env.DAGGER_PLAN }}
+        run: dagger do -l error deploy -w "actions:deploy:\"${{ env.AWS_REGION }}\":\"${{ env.ENV_TAG }}\":latest:\"${{ env.SHA_TAG }}\":_" -p ${{ env.DAGGER_PLAN }}
       -
         name: Set commit status "success"
         run: dagger do success -p ${{ env.STATUS_PLAN }}


### PR DESCRIPTION
This is an indication to the CD manager to pull the latest branch commit hash for the deployment.