### PR TITLE
fix: Use stream's state metadata to generate merkle tree metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint": "./node_modules/.bin/eslint --fix ./src --ext .js,.jsx,.ts,.tsx",
     "typeorm": "./node_modules/.bin/ts-node -r tsconfig-paths/register ./node_modules//typeorm/cli.js",
     "clean": "rm -rf ./build; rm -rf coverage; rm -rf .nyc_output",
-    "start": "node --loader ts-node/esm ./build/main.js",
+    "start": "node --loader tsm ./build/main.js",
     "startDev": "NODE_ENV=dev APP_MODE=bundled node ./build/main.js ",
     "watch": "./node_modules/.bin/nodemon -e ts --watch src --exec \"npm run build && npm run start\"",
     "buildContract": "cd contracts; make build",

--- a/src/merkle/__tests__/merkle-metadata.test.ts
+++ b/src/merkle/__tests__/merkle-metadata.test.ts
@@ -32,7 +32,7 @@ describe('Bloom filter', () => {
       id: new StreamID('tile', cid),
       tip: cid,
       metadata,
-      state: { anchorStatus: AnchorStatus.PENDING, log: [{ cid }] },
+      state: { anchorStatus: AnchorStatus.PENDING, log: [{ cid }], metadata },
     }
     const candidate = new Candidate(stream.id, [new Request()])
     candidate.setTipToAnchor(stream as any)

--- a/src/merkle/merkle-objects.ts
+++ b/src/merkle/merkle-objects.ts
@@ -157,7 +157,7 @@ export class Candidate implements CIDHolder {
       this._alreadyAnchored = true
     } else {
       this._cid = stream.tip
-      this._metadata = stream.metadata as StreamMetadata
+      this._metadata = stream.state.metadata as StreamMetadata
     }
 
     // Check the log of the Stream that was loaded from Ceramic to see which of the pending requests

--- a/src/merkle/merkle-objects.ts
+++ b/src/merkle/merkle-objects.ts
@@ -157,7 +157,9 @@ export class Candidate implements CIDHolder {
       this._alreadyAnchored = true
     } else {
       this._cid = stream.tip
-      this._metadata = stream.state.metadata as StreamMetadata
+      this._metadata = stream.state.next?.metadata
+        ? stream.state.next.metadata
+        : stream.state.metadata
     }
 
     // Check the log of the Stream that was loaded from Ceramic to see which of the pending requests

--- a/src/services/__tests__/anchor-service.test.ts
+++ b/src/services/__tests__/anchor-service.test.ts
@@ -77,6 +77,7 @@ function createStream(id: StreamID, log: CID[], anchorStatus: AnchorStatus = Anc
         return { cid }
       }),
       anchorStatus,
+      metadata: { controllers: ['this is totally a did'] },
     },
     tip: log[log.length - 1],
   }


### PR DESCRIPTION
```
[2022-09-20T14:42:09.433Z] ERROR: 'Error when anchoring: Error: Merkle tree cannot be created: TypeError: candidate.metadata.controllers is not iterable' Will look into fixing
```

No tests because that is a larger effort (adding to the ceramic_integration repo and setting up all the model stuff)