### PR TITLE
fix: use min stream count when marking requests as ready using the scheduler

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -6,7 +6,7 @@
   "schedulerIntervalMS": 300000,
   "expirationPeriod": 5400000,
   "merkleDepthLimit": 0,
-  "minStreamCount": 1,
+  "minStreamCount": 1024,
   "anchorLauncherUrl": "http://localhost:8001",
   "maxAnchoringDelayMS": 43200000,
   "ipfsConfig": {

--- a/src/services/__tests__/anchor-service.test.ts
+++ b/src/services/__tests__/anchor-service.test.ts
@@ -887,7 +887,7 @@ describe('anchor service', () => {
         {
           status: RequestStatus.PENDING,
         },
-        streamLimit - 1
+        minStreamCount - 1
       )
 
       const requestRepository = container.resolve<RequestRepository>('requestRepository')

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -286,10 +286,14 @@ export class AnchorService {
 
       Metrics.count(METRIC_NAMES.RETRY_EMIT_ANCHOR_EVENT, readyRequests.length)
     } else {
-      const streamLimit =
+      const maxStreamLimit =
         this.config.merkleDepthLimit > 0 ? Math.pow(2, this.config.merkleDepthLimit) : 0
+      const minStreamLimit = this.config.minStreamCount || Math.floor(maxStreamLimit / 2)
 
-      const updatedRequests = await this.requestRepository.findAndMarkReady(streamLimit)
+      const updatedRequests = await this.requestRepository.findAndMarkReady(
+        maxStreamLimit,
+        minStreamLimit
+      )
 
       if (updatedRequests.length === 0) {
         return


### PR DESCRIPTION
Originally we wanted the min stream count = max stream count aka only anchor when we have a 1024 streams or streams are expiring.

This means that we will have to set MIN_STREAM_COUNT to something in dev and prod otherwise it will default to 1 (default.json) 