### PR TITLE
ci: rename test workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,8 +83,7 @@ jobs:
       - send-dispatch-event
 
 workflows:
-  test:
-    name: Test and Queue Deploy
+  test_and_queue_deploy:
     jobs:
       - test
       - dispatch-event:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,7 @@ jobs:
 
 workflows:
   test:
+    name: Test and Queue Deploy
     jobs:
       - test
       - dispatch-event:


### PR DESCRIPTION
Just rename the test workflow so that it is more obvious what is running in the github ui