### PR TITLE
fix: serializable isolation lvl and already anchored check

### DIFF
--- a/src/repositories/request-repository.ts
+++ b/src/repositories/request-repository.ts
@@ -45,8 +45,7 @@ export class RequestRepository extends Repository<Request> {
     @inject('dbConnection') private connection?: Connection
   ) {
     super()
-    this.isolationLevel =
-      this.connection.options.type === 'sqlite' ? 'SERIALIZABLE' : 'REPEATABLE READ'
+    this.isolationLevel = 'SERIALIZABLE'
   }
 
   /**


### PR DESCRIPTION
Use serializable isolation level to prevent concurrent updates from making unpredictable updates

Check if the newest request was already anchored, if so mark all those requests as anchored