### PR TITLE
fix: use db transaction when updating expiring ready requests

### DIFF
--- a/src/repositories/request-repository.ts
+++ b/src/repositories/request-repository.ts
@@ -387,8 +387,8 @@ export class RequestRepository {
   }
 
   /**
-   * Finds and updates all READY requests that have not been moved to PROCESSING in a sufficient amount of time
-   * Updates them again to indicate that they are being retried
+   * Finds and updates all READY requests that are expired (have not been moved to PROCESSING in a sufficient amount of time)
+   * Updating them indicates that they are being retried
    * @param options
    * @returns A promise for the number of expired ready requests updated
    */
@@ -411,7 +411,7 @@ export class RequestRepository {
           }
 
           // since the expiration of ready requests are determined by their "updated_at" field, update the requests again
-          // to indicate that a new anchor event has been emitted
+          // to indicate that they are being retried
           const updatedCount = await this.updateRequests(
             { status: RequestStatus.READY },
             readyRequests,

--- a/src/repositories/request-repository.ts
+++ b/src/repositories/request-repository.ts
@@ -392,7 +392,7 @@ export class RequestRepository {
    * @param options
    * @returns A promise for the number of expired ready requests updated
    */
-  public async updateExpiringReadyRequests(options: Options = {}): Promise<Number> {
+  public async updateExpiringReadyRequests(options: Options = {}): Promise<number> {
     const { connection = this.connection } = options
 
     return await connection

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -273,8 +273,6 @@ export class AnchorService {
    * mark them as PROCESSING, and perform an anchor.
    */
   public async emitAnchorEventIfReady(): Promise<void> {
-    const readyRequests = await this.requestRepository.findByStatus(RS.READY)
-
     const updatedExpiredReadyRequestsCount =
       await this.requestRepository.updateExpiringReadyRequests()
 
@@ -284,7 +282,7 @@ export class AnchorService {
       logger.debug(
         `Emitting an anchor event beacuse ${updatedExpiredReadyRequestsCount} READY requests expired`
       )
-      Metrics.count(METRIC_NAMES.RETRY_EMIT_ANCHOR_EVENT, readyRequests.length)
+      Metrics.count(METRIC_NAMES.RETRY_EMIT_ANCHOR_EVENT, updatedExpiredReadyRequestsCount)
     } else {
       const maxStreamLimit =
         this.config.merkleDepthLimit > 0 ? Math.pow(2, this.config.merkleDepthLimit) : 0

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -274,21 +274,13 @@ export class AnchorService {
    */
   public async emitAnchorEventIfReady(): Promise<void> {
     const readyRequests = await this.requestRepository.findByStatus(RS.READY)
-    const readyDeadline = Date.now() - this.config.readyRetryIntervalMS
 
-    if (readyRequests.length > 0) {
-      const earliestNotTimedOut = readyDeadline < readyRequests[0].updatedAt.getTime()
-      if (earliestNotTimedOut) {
-        return
-      }
-      // since the expiration of ready requests are determined by their "updated_at" field, update the requests again
-      // to indicate that a new anchor event has been emitted
-      const updatedCount = await this.requestRepository.updateRequests(
-        { status: RS.READY },
-        readyRequests
+    const updatedExpiredReadyRequestsCount =
+      await this.requestRepository.updateExpiringReadyRequests()
+    if (updatedExpiredReadyRequestsCount > 0) {
+      logger.debug(
+        `Emitting an anchor event beacuse ${updatedExpiredReadyRequestsCount} READY requests expired`
       )
-
-      logger.debug(`Emitting an anchor event beacuse ${updatedCount} READY requests expired`)
       Metrics.count(METRIC_NAMES.RETRY_EMIT_ANCHOR_EVENT, readyRequests.length)
     } else {
       const maxStreamLimit =
@@ -460,7 +452,7 @@ export class AnchorService {
       acceptedRequests.push(...candidate.acceptedRequests)
     }
 
-    const trx = await this.connection.transaction()
+    const trx = await this.connection.transaction(null, { isolationLevel: 'serializable' })
     try {
       await this.anchorRepository.createAnchors(anchors, { connection: trx })
 

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -277,6 +277,9 @@ export class AnchorService {
 
     const updatedExpiredReadyRequestsCount =
       await this.requestRepository.updateExpiringReadyRequests()
+
+    // if ready requests have been updated because they have expired
+    // we will retry them by emitting an anchor event and not marking anymore requests as READY
     if (updatedExpiredReadyRequestsCount > 0) {
       logger.debug(
         `Emitting an anchor event beacuse ${updatedExpiredReadyRequestsCount} READY requests expired`


### PR DESCRIPTION
When updating expiring ready requests we were not using a db transaction. 

1a. Scheduler service gathers expired ready requests which include requestA
1b. requestA is at the SAME time being updated to PENDING and added to a batch
2. all requests gathered in step 1a are updated to READY via the scheduler service
requestA should have status PENDING but because of step 2 it is READY

3a. The scheduler service gathers expired ready requests and thinks requestA is READY and expired
3b. The batch completes and requestA is at the SAME time being updated to COMPLETED
4. All requests gathered in step 3a are updated to READY via the scheduler service
requestA should have status COMPLETED but because of step 4 it is READY

Not ideal at all so I put steps 1a + 2 into a db transaction to prevent the updates using old row data