### PR TITLE
Metrics on Anchor Request Timing

### DIFF
--- a/src/controllers/anchor-controller.ts
+++ b/src/controllers/anchor-controller.ts
@@ -6,6 +6,8 @@ import cors from 'cors'
 import { Controller, Get, ClassMiddleware, Post } from '@overnightjs/core'
 
 import { AnchorService } from '../services/anchor-service.js'
+import { ServiceMetrics as Metrics } from '../service-metrics.js'
+import { METRIC_NAMES } from '../settings.js'
 
 import type { Response } from 'express-serve-static-core'
 import { singleton } from 'tsyringe'
@@ -19,8 +21,12 @@ export class AnchorController {
 
   @Post()
   private async anchor(req: ExpReq, res: ExpRes): Promise<Response> {
+    const before = performance.now()
     try {
       await this.anchorService.anchorRequests()
+
+      const after = performance.now()
+      Metrics.record(METRIC_NAMES.ANCHOR_REQUESTS_BATCH_TIME, after - before)
 
       return res.status(OK).json({
         message: 'anchored pending streams',
@@ -28,6 +34,10 @@ export class AnchorController {
     } catch (err) {
       const errmsg = `Anchoring pending streams failed: ${err.message}`
       logger.err(errmsg)
+
+      const after = performance.now()
+      Metrics.record(METRIC_NAMES.ANCHOR_REQUESTS_BATCH_FAILURE_TIME, after - before)
+
       return res.status(INTERNAL_SERVER_ERROR).json({
         error: errmsg,
       })

--- a/src/controllers/request-controller.ts
+++ b/src/controllers/request-controller.ts
@@ -96,7 +96,7 @@ export class RequestController {
       } else {
         // Intentionally don't await the pinStream promise, let it happen in the background.
         this.ceramicService.pinStream(streamId)
-        Metrics.count(METRIC_NAMES.PIN_REQUESTED, 1)
+        Metrics.count(METRIC_NAMES.ANCHOR_REQUESTED, 1, {'ip_addr': req.ip})
 
         request = new Request()
         request.cid = cid.toString()

--- a/src/repositories/request-repository.ts
+++ b/src/repositories/request-repository.ts
@@ -48,7 +48,7 @@ const recordAnchorRequestMetrics = (requests: Request[], anchoringDeadline: Date
   }
 
   expired.publishStats(METRIC_NAMES.RETRY_EXPIRING)
-  processing.publishStats(METRIC_NAMES.RETRY_PROCESSING)
+  processing.publishStats(METRIC_NAMES.RETRY_PROCESSING) // Is this really retry??
   failed.publishStats(METRIC_NAMES.RETRY_FAILED)
 }
 
@@ -257,8 +257,11 @@ export class RequestRepository {
               `A problem occured when updated requests to PROCESSING. Only ${updatedCount}/${requests.length} requests were updated`
             )
           }
-          // at this point record times from now - updatedat  (we didn't update the requests in memory just the db)
-          // mean, max, the status will be PROCESSING in all cases
+
+          // Record the timing of the processing requests, relative to the last update (when we submitted them)
+          const processing = new TimeableMetric(SinceField.UpdatedAt)
+          processing.recordAll(requests)
+          processing.publishStats(METRIC_NAMES.READY_PROCESSING)
           return requests
         },
         {

--- a/src/repositories/request-repository.ts
+++ b/src/repositories/request-repository.ts
@@ -33,9 +33,9 @@ export const TABLE_NAME = 'request'
  * @returns
  */
 const recordAnchorRequestMetrics = (requests: Request[], anchoringDeadline: Date): void => {
-  const expired = new TimeableMetric(SinceField.CreatedAt)
-  const processing = new TimeableMetric(SinceField.CreatedAt)
-  const failed = new TimeableMetric(SinceField.CreatedAt)
+  const expired = new TimeableMetric(SinceField.CREATED_AT)
+  const processing = new TimeableMetric(SinceField.CREATED_AT)
+  const failed = new TimeableMetric(SinceField.CREATED_AT)
 
   for (const req of requests) {
       if (req.createdAt < anchoringDeadline) {
@@ -259,7 +259,7 @@ export class RequestRepository {
           }
 
           // Record the timing of the processing requests, relative to the last update (when we submitted them)
-          const processing = new TimeableMetric(SinceField.UpdatedAt)
+          const processing = new TimeableMetric(SinceField.UPDATED_AT)
           processing.recordAll(requests)
           processing.publishStats(METRIC_NAMES.READY_PROCESSING)
           return requests

--- a/src/repositories/request-repository.ts
+++ b/src/repositories/request-repository.ts
@@ -48,7 +48,7 @@ const recordAnchorRequestMetrics = (requests: Request[], anchoringDeadline: Date
   }
 
   expired.publishStats(METRIC_NAMES.RETRY_EXPIRING)
-  processing.publishStats(METRIC_NAMES.RETRY_PROCESSING) // Is this really retry??
+  processing.publishStats(METRIC_NAMES.RETRY_PROCESSING)
   failed.publishStats(METRIC_NAMES.RETRY_FAILED)
 }
 
@@ -258,7 +258,7 @@ export class RequestRepository {
             )
           }
 
-          // Record the timing of the processing requests, relative to the last update (when we submitted them)
+          // Record the requests we are processing, along with the time since they were marked as ready.
           const processing = new TimeableMetric(SinceField.UPDATED_AT)
           processing.recordAll(requests)
           processing.publishStats(METRIC_NAMES.READY_PROCESSING)

--- a/src/service-metrics.ts
+++ b/src/service-metrics.ts
@@ -84,15 +84,15 @@ export class TimeableMetric {
   public record(request: Timeable) {
 
     this.cnt += 1
-    let time_elapsed = 0
+    let timeElapsed = 0
     if (this.since === SinceField.CREATED_AT) {
-      time_elapsed = Date.now() - request.createdAt.getTime()
+      timeElapsed = Date.now() - request.createdAt.getTime()
     } else { // UpdatedAt
-      time_elapsed = Date.now() - request.updatedAt.getTime()
+      timeElapsed = Date.now() - request.updatedAt.getTime()
     }
-    this.totTime += time_elapsed
-    if (time_elapsed > this.maxTime) {
-      this.maxTime = time_elapsed
+    this.totTime += timeElapsed
+    if (timeElapsed > this.maxTime) {
+      this.maxTime = timeElapsed
     }
   }
 

--- a/src/service-metrics.ts
+++ b/src/service-metrics.ts
@@ -82,10 +82,6 @@ export class TimeableMetric {
   }
 
   public record(request: Timeable) {
-    // we could lean on prometheus to do this but it might be too heavyweight
-    // so calculate the average ourselves
-    // the Request class is imported from CAS but we could make it an interface
-    // it only requires createdAt and 
 
     this.cnt += 1
     let time_elapsed = 0

--- a/src/service-metrics.ts
+++ b/src/service-metrics.ts
@@ -75,6 +75,12 @@ export class TimeableMetric {
     this.since = since
   } 
 
+  public recordAll(requests: Timeable[]) {
+     for (const req of requests) {
+       this.record(req)
+     }
+  }
+
   public record(request: Timeable) {
     // we could lean on prometheus to do this but it might be too heavyweight
     // so calculate the average ourselves

--- a/src/service-metrics.ts
+++ b/src/service-metrics.ts
@@ -58,8 +58,8 @@ class NullSpan implements Endable {
 }
 
 export enum SinceField {
-  CreatedAt = 0,
-  UpdatedAt = 1
+  CREATED_AT = 0,
+  UPDATED_AT = 1
 }
 
 export class TimeableMetric {
@@ -89,7 +89,7 @@ export class TimeableMetric {
 
     this.cnt += 1
     let time_elapsed = 0
-    if (this.since === SinceField.CreatedAt) {
+    if (this.since === SinceField.CREATED_AT) {
       time_elapsed = Date.now() - request.createdAt.getTime()
     } else { // UpdatedAt
       time_elapsed = Date.now() - request.updatedAt.getTime()

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -137,10 +137,11 @@ export class AnchorService {
 
     logger.imp('Anchoring ready requests...')
     logger.debug(`Loading requests from the database`)
-    // Metric for performance.now()
+    const before = performance.now()
     const requests: Request[] = await this.requestRepository.findAndMarkAsProcessing()
     await this._anchorRequests(requests)
-
+    const after = performance.now()
+    Metrics.record(METRIC_NAMES.ANCHOR_REQUESTS_BATCH_TIME, after - before)
     // Sleep 5 seconds before exiting the process to give time for the logs to flush.
     await Utils.delay(5000)
   }

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -17,7 +17,7 @@ import { TransactionRepository } from '../repositories/transaction-repository.js
 import { IpfsService } from './ipfs-service.js'
 import { EventProducerService } from './event-producer/event-producer-service.js'
 import { CeramicService } from './ceramic-service.js'
-import { ServiceMetrics as Metrics } from '../service-metrics.js'
+import { ServiceMetrics as Metrics, TimeableMetric, SinceField } from '../service-metrics.js'
 import { METRIC_NAMES } from '../settings.js'
 import { BlockchainService } from './blockchain/blockchain-service.js'
 import { inject, singleton } from 'tsyringe'
@@ -474,6 +474,8 @@ export class AnchorService {
       await trx.rollback()
       throw err
     }
+    const completed = new TimeableMetric(SinceField.CREATED_AT)
+    completed.recordAll(acceptedRequests)
 
     Metrics.count(METRIC_NAMES.ACCEPTED_REQUESTS, acceptedRequests.length)
     return acceptedRequests.length

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -153,8 +153,6 @@ export class AnchorService {
       logger.debug('No pending CID requests found. Skipping anchor.')
       return
     }
-    // we still have pristine requests here (until _findCandidates)
-    // this is the function we want to trace.span()
 
     let streamCountLimit = 0 // 0 means no limit
     if (this.config.merkleDepthLimit > 0) {

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -129,6 +129,7 @@ export class AnchorService {
   public async anchorReadyRequests(): Promise<void> {
     // TODO: Remove this after restart loop removed as part of switching to go-ipfs
     // Skip sleep for unit tests
+    // this is the whole function if we want to time it
     if (process.env.NODE_ENV != 'test') {
       logger.imp('sleeping one minute for ipfs to stabilize')
       await Utils.delay(1000 * 60)
@@ -136,6 +137,7 @@ export class AnchorService {
 
     logger.imp('Anchoring ready requests...')
     logger.debug(`Loading requests from the database`)
+    // Metric for performance.now()
     const requests: Request[] = await this.requestRepository.findAndMarkAsProcessing()
     await this._anchorRequests(requests)
 
@@ -153,6 +155,8 @@ export class AnchorService {
       logger.debug('No pending CID requests found. Skipping anchor.')
       return
     }
+    // we still have pristine requests here (until _findCandidates)
+    // this is the function we want to trace.span()
 
     let streamCountLimit = 0 // 0 means no limit
     if (this.config.merkleDepthLimit > 0) {

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -129,7 +129,6 @@ export class AnchorService {
   public async anchorReadyRequests(): Promise<void> {
     // TODO: Remove this after restart loop removed as part of switching to go-ipfs
     // Skip sleep for unit tests
-    // this is the whole function if we want to time it
     if (process.env.NODE_ENV != 'test') {
       logger.imp('sleeping one minute for ipfs to stabilize')
       await Utils.delay(1000 * 60)
@@ -137,11 +136,9 @@ export class AnchorService {
 
     logger.imp('Anchoring ready requests...')
     logger.debug(`Loading requests from the database`)
-    const before = performance.now()
     const requests: Request[] = await this.requestRepository.findAndMarkAsProcessing()
     await this._anchorRequests(requests)
-    const after = performance.now()
-    Metrics.record(METRIC_NAMES.ANCHOR_REQUESTS_BATCH_TIME, after - before)
+
     // Sleep 5 seconds before exiting the process to give time for the logs to flush.
     await Utils.delay(5000)
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,7 @@
 export enum METRIC_NAMES {
+
+  ANCHOR_REQUESTS_BATCH_TIME = 'anchor_requests_batch_time',
+
   ANCHOR_SUCCESS = 'anchor_success',
   ANCHOR_TIMEOUT = 'anchor_timeout',
   ERROR_ETH = 'error_eth',
@@ -17,7 +20,8 @@ export enum METRIC_NAMES {
   PIN_SUCCEEDED = 'pin_succeeded',
   PIN_FAILED = 'pin_failed',
 
-  RETRY_PROCESSING = 'retry_processing',
+  READY_PROCESSING = 'ready_processing', // is this a good name ??
+  RETRY_PROCESSING = 'retry_processing', // is this really being used for retry only?
   RETRY_FAILED = 'retry_failed',
   RETRY_EXPIRING = 'retry_expiring',
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -22,10 +22,17 @@ export enum METRIC_NAMES {
   PIN_SUCCEEDED = 'pin_succeeded',
   PIN_FAILED = 'pin_failed',
 
-  READY_PROCESSING = 'ready_processing', // is this a good name ??
-  RETRY_PROCESSING = 'retry_processing', // is this really being used for retry only?
+  // request that moves from ready -> processing
+  READY_PROCESSING = 'ready_processing',
+
+  // when a request is created, expired or completes
+  REQUEST_CREATED = 'request_created',
+  REQUEST_EXPIRED = 'request_expired',
+  REQUEST_COMPLETED = 'request_completed',
+
+  // retries that move to processing or failed
+  RETRY_PROCESSING = 'retry_processing',
   RETRY_FAILED = 'retry_failed',
-  RETRY_EXPIRING = 'retry_expiring',
 
   TIME_ANCHOR_COMMITS_MS = 'time_anchor_commits_ms',
   TIME_TREE_COMMIT_MS = 'time_tree_commit_ms',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,7 @@
 export enum METRIC_NAMES {
 
   ANCHOR_REQUESTS_BATCH_TIME = 'anchor_requests_batch_time',
+  ANCHOR_REQUESTS_BATCH_FAILURE_TIME = 'anchor_requests_batch_failure_time',
 
   ANCHOR_SUCCESS = 'anchor_success',
   ANCHOR_TIMEOUT = 'anchor_timeout',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,6 @@
 export enum METRIC_NAMES {
 
+  ANCHOR_REQUESTED = 'anchor_requested',
   ANCHOR_REQUESTS_BATCH_TIME = 'anchor_requests_batch_time',
   ANCHOR_REQUESTS_BATCH_FAILURE_TIME = 'anchor_requests_batch_failure_time',
 


### PR DESCRIPTION
# Add Metrics on Timing between Request and Anchor - #PLAT-844
# Add metrics for status changes - #CDB-1982

## Description

In the request-repostiory add metrics to findAndMarkReady to monitor how long a request takes to be marked as READY (now - createdAt) (not sure if we want average or a range or  the longest)

In the request-repository add metrics to findAndMarkAsProcessing to monitor how long a request takes to be marked as PROCESSING (now - updatedAt) (not sure if we want average or a range or  the longest)

Also addresses overall timing between request and anchor (PLAT-844)

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x] Unit tests pass
- [ ] Deploy to dev as branch

## Definition of Done

Before submitting this PR, please make sure:

- [ x] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ x] My code follows conventions, is well commented, and easy to understand
- [ x] My code builds and tests pass without any errors or warnings
- [ x] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ x] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
