### PR TITLE
Add model to bloom filter + remove schema, family and tags

### DIFF
--- a/src/merkle/__tests__/merkle-metadata.test.ts
+++ b/src/merkle/__tests__/merkle-metadata.test.ts
@@ -57,21 +57,17 @@ describe('Bloom filter', () => {
     expect(metadata.streamIds).toEqual([candidates[0].streamId.toString()])
     expect(isTypeString(metadata.bloomFilter.type)).toEqual(true)
 
-    // @ts-ignore
     const bloomFilter = BloomFilter.fromString(metadata.bloomFilter.data)
-
     expect(bloomFilter.contains(`streamid-${candidates[0].streamId.toString()}`)).toBeTruthy()
     expect(bloomFilter.contains(`controller-a`)).toBeTruthy()
     expect(bloomFilter.contains(`controller-b`)).toBeFalsy()
   })
 
-  test('Single stream full metadata', async () => {
+  test('Single stream with model', async () => {
     const merkleTree = makeMerkleTree()
     const streamMetadata = {
-      controllers: ['a', 'b'],
-      schema: 'schema',
-      family: 'family',
-      tags: ['a', 'b'],
+      controllers: ['a'],
+      model: 'model',
     }
     const candidates = [await createCandidate(streamMetadata)]
     await merkleTree.build(candidates)
@@ -81,40 +77,29 @@ describe('Bloom filter', () => {
     expect(metadata.streamIds).toEqual([candidates[0].streamId.toString()])
     expect(isTypeString(metadata.bloomFilter.type)).toEqual(true)
 
-    // @ts-ignore
     const bloomFilter = BloomFilter.fromString(metadata.bloomFilter.data)
-
     expect(bloomFilter.contains(`streamid-${candidates[0].streamId.toString()}`)).toBeTruthy()
     expect(bloomFilter.contains(`controller-a`)).toBeTruthy()
-    expect(bloomFilter.contains(`controller-b`)).toBeTruthy()
-    expect(bloomFilter.contains(`controller-c`)).toBeFalsy()
+    expect(bloomFilter.contains(`controller-b`)).toBeFalsy()
     expect(bloomFilter.contains(`a`)).toBeFalsy()
-    expect(bloomFilter.contains(`schema-schema`)).toBeTruthy()
-    expect(bloomFilter.contains(`family-family`)).toBeTruthy()
-    expect(bloomFilter.contains(`tag-a`)).toBeTruthy()
-    expect(bloomFilter.contains(`tag-b`)).toBeTruthy()
-    expect(bloomFilter.contains(`tag-c`)).toBeFalsy()
+    expect(bloomFilter.contains(`model-model`)).toBeTruthy()
   })
 
-  test('Multiple streams full metadata', async () => {
+  test('Multiple streams with model', async () => {
     const merkleTree = makeMerkleTree()
     const streamMetadata0 = {
-      controllers: ['a', 'b'],
-      schema: 'schema0',
+      controllers: ['a'],
+      model: 'model0',
       family: 'family0',
       tags: ['a', 'b'],
     }
     const streamMetadata1 = {
       controllers: ['a'],
-      schema: 'schema1',
-      family: 'family0',
-      tags: ['a', 'b', 'c', 'd'],
+      model: 'model1',
     }
     const streamMetadata2 = {
-      controllers: ['b', 'c'],
-      schema: 'schema2',
-      family: 'family1',
-      tags: ['a', 'c', 'e'],
+      controllers: ['b'],
+      model: 'model2',
     }
     const candidates = await Promise.all([
       createCandidate(streamMetadata0),
@@ -130,29 +115,17 @@ describe('Bloom filter', () => {
     )
     expect(isTypeString(metadata.bloomFilter.type)).toEqual(true)
 
-    // @ts-ignore
     const bloomFilter = BloomFilter.fromString(metadata.bloomFilter.data)
-
     expect(bloomFilter.contains(`streamid-${candidates[0].streamId.toString()}`)).toBeTruthy()
     expect(bloomFilter.contains(`streamid-${candidates[1].streamId.toString()}`)).toBeTruthy()
     expect(bloomFilter.contains(`streamid-${candidates[2].streamId.toString()}`)).toBeTruthy()
     expect(bloomFilter.contains(`controller-a`)).toBeTruthy()
     expect(bloomFilter.contains(`controller-b`)).toBeTruthy()
-    expect(bloomFilter.contains(`controller-c`)).toBeTruthy()
-    expect(bloomFilter.contains(`controller-d`)).toBeFalsy()
+    expect(bloomFilter.contains(`controller-c`)).toBeFalsy()
     expect(bloomFilter.contains(`a`)).toBeFalsy()
-    expect(bloomFilter.contains(`schema-schema0`)).toBeTruthy()
-    expect(bloomFilter.contains(`schema-schema1`)).toBeTruthy()
-    expect(bloomFilter.contains(`schema-schema2`)).toBeTruthy()
-    expect(bloomFilter.contains(`schema-schema3`)).toBeFalsy()
-    expect(bloomFilter.contains(`family-family0`)).toBeTruthy()
-    expect(bloomFilter.contains(`family-family1`)).toBeTruthy()
-    expect(bloomFilter.contains(`family-family2`)).toBeFalsy()
-    expect(bloomFilter.contains(`tag-a`)).toBeTruthy()
-    expect(bloomFilter.contains(`tag-b`)).toBeTruthy()
-    expect(bloomFilter.contains(`tag-c`)).toBeTruthy()
-    expect(bloomFilter.contains(`tag-d`)).toBeTruthy()
-    expect(bloomFilter.contains(`tag-e`)).toBeTruthy()
-    expect(bloomFilter.contains(`tag-f`)).toBeFalsy()
+    expect(bloomFilter.contains(`model-model0`)).toBeTruthy()
+    expect(bloomFilter.contains(`model-model1`)).toBeTruthy()
+    expect(bloomFilter.contains(`model-model2`)).toBeTruthy()
+    expect(bloomFilter.contains(`model-model3`)).toBeFalsy()
   })
 })

--- a/src/merkle/merkle-objects.ts
+++ b/src/merkle/merkle-objects.ts
@@ -253,16 +253,8 @@ export class BloomMetadata implements MetadataFunction<Candidate, TreeMetadata> 
       const candidate = node.data
       streamIds.push(candidate.streamId.toString())
       bloomFilterEntries.add(`streamid-${candidate.streamId.toString()}`)
-      if (candidate.metadata.schema) {
-        bloomFilterEntries.add(`schema-${candidate.metadata.schema}`)
-      }
-      if (candidate.metadata.family) {
-        bloomFilterEntries.add(`family-${candidate.metadata.family}`)
-      }
-      if (candidate.metadata.tags) {
-        for (const tag of candidate.metadata.tags) {
-          bloomFilterEntries.add(`tag-${tag}`)
-        }
+      if (candidate.metadata.model) {
+        bloomFilterEntries.add(`model-${candidate.metadata.model.toString()}`)
       }
       for (const controller of candidate.metadata.controllers) {
         bloomFilterEntries.add(`controller-${controller}`)


### PR DESCRIPTION
## Description

Adds the `model` id to the bloom filter if available and remove the `schema`, `family` and `tags`. 

## How Has This Been Tested?

- [x] Updated existing tests

## Definition of Done

Before submitting this PR, please make sure:

- [x] The work addresses the description and outcomes in the issue
- [x] I have added relevant tests for new or updated functionality
- [x] My code follows conventions, is well commented, and easy to understand
- [x] My code builds and tests pass without any errors or warnings
- [x] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [x] The changes have been communicated to interested parties
