### PR TITLE
fix: anchor proofs use txType instead of version

### DIFF
--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -33,6 +33,8 @@ import {
 import { v4 as uuidv4 } from 'uuid'
 import type { Knex } from 'knex'
 
+const CONTRACT_TX_TYPE = 'f(bytes32)'
+
 type RequestGroups = {
   alreadyAnchoredRequests: Request[]
   conflictingRequests: Request[]
@@ -357,7 +359,7 @@ export class AnchorService {
       txHash: txHashCid,
     } as any
 
-    if (this.config.useSmartContractAnchors) ipfsAnchorProof.version = 1
+    if (this.config.useSmartContractAnchors) ipfsAnchorProof.txType = CONTRACT_TX_TYPE
 
     logger.debug('Anchor proof: ' + JSON.stringify(ipfsAnchorProof))
     const ipfsProofCid = await this.ipfsService.storeRecord(ipfsAnchorProof)


### PR DESCRIPTION
See description of https://github.com/ceramicnetwork/js-ceramic/pull/2565