### PR TITLE
fix: check for empty anchors

### DIFF
--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -467,7 +467,9 @@ export class AnchorService {
 
     const trx = await this.connection.transaction(null, { isolationLevel: 'repeatable read' })
     try {
-      await this.anchorRepository.createAnchors(anchors, { connection: trx })
+      if (anchors.length > 0) {
+        await this.anchorRepository.createAnchors(anchors, { connection: trx })
+      }
 
       await this.requestRepository.updateRequests(
         {


### PR DESCRIPTION
Very unlikely to happen but if the creating the anchor commit on ipfs step fails, we could have no anchor commits to insert into the db. And that is what we saw in QA. 