### PR TITLE
feat: Let load stream timeout be configurable

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -5,7 +5,7 @@
   "anchorControllerEnabled": false,
   "anchorLauncherUrl": "http://localhost:8001",
   "expirationPeriod": 5400000,
-  "loadStreamTimeoutMs": 6000,
+  "loadStreamTimeoutMs": 60000,
   "maxAnchoringDelayMS": 43200000,
   "merkleDepthLimit": 0,
   "minStreamCount": 1024,

--- a/config/default.json
+++ b/config/default.json
@@ -5,6 +5,7 @@
   "anchorControllerEnabled": false,
   "anchorLauncherUrl": "http://localhost:8001",
   "expirationPeriod": 5400000,
+  "loadStreamTimeoutMs": 6000,
   "maxAnchoringDelayMS": 43200000,
   "merkleDepthLimit": 0,
   "minStreamCount": 1024,

--- a/config/env/dev.json
+++ b/config/env/dev.json
@@ -4,6 +4,7 @@
   "anchorControllerEnabled": "@@ANCHOR_CONTROLLER_ENABLED",
   "anchorLauncherUrl": "@@ANCHOR_LAUNCHER_URL",
   "expirationPeriod": "@@ANCHOR_EXPIRATION_PERIOD",
+  "loadStreamTimeoutMs": "@@LOAD_STREAM_TIMEOUT_MS",
   "maxAnchoringDelayMS": "@@MAX_ANCHORING_DELAY_MS",
   "merkleDepthLimit": "@@MERKLE_DEPTH_LIMIT",
   "minStreamCount": "@@MIN_STREAM_COUNT",

--- a/config/env/prod.json
+++ b/config/env/prod.json
@@ -4,6 +4,7 @@
   "anchorControllerEnabled": "@@ANCHOR_CONTROLLER_ENABLED",
   "anchorLauncherUrl": "@@ANCHOR_LAUNCHER_URL",
   "expirationPeriod": "@@ANCHOR_EXPIRATION_PERIOD",
+  "loadStreamTimeoutMs": "@@LOAD_STREAM_TIMEOUT_MS",
   "maxAnchoringDelayMS": "@@MAX_ANCHORING_DELAY_MS",
   "merkleDepthLimit": "@@MERKLE_DEPTH_LIMIT",
   "minStreamCount": "@@MIN_STREAM_COUNT",

--- a/config/env/test.json
+++ b/config/env/test.json
@@ -1,6 +1,7 @@
 {
   "anchorLauncherUrl": "http://localhost:8001",
   "expirationPeriod": 0,
+  "loadStreamTimeoutMs": 1000,
   "readyRetryIntervalMS": 10000,
   "schedulerIntervalMS": 10000,
   "ceramic": {

--- a/src/services/ceramic-service.ts
+++ b/src/services/ceramic-service.ts
@@ -17,7 +17,7 @@ export interface CeramicService {
   unpinStream(streamId: StreamID): Promise<void>
 }
 
-const LOAD_STREAM_TIMEOUT = 1000 * 60 // 1 minute
+const DEFAULT_LOAD_STREAM_TIMEOUT = 1000 * 60 // 1 minute
 const MULTIQUERY_SERVER_TIMEOUT = 1000 * 60 // 1 minute
 // 10 seconds more than server-side timeout so server-side timeout can fire first, which gives us a
 // more useful error message
@@ -50,7 +50,7 @@ export class CeramicServiceImpl implements CeramicService {
     const timeoutPromise = new Promise((_, reject) => {
       timeout = setTimeout(() => {
         reject(new Error(`Timed out loading stream: ${streamId.toString()}`))
-      }, LOAD_STREAM_TIMEOUT)
+      }, this.config.loadStreamTimeoutMs || DEFAULT_LOAD_STREAM_TIMEOUT)
     })
 
     return (await Promise.race([streamPromise, timeoutPromise])) as T


### PR DESCRIPTION
The goal is that we can set this down on clay (probably to 1 second) so that Clay batches won't take so long to complete (given that we get a lot of stream load timeouts on clay, where it is more expected)