### PR TITLE
fix: get around postgres parameterized query limit

### DIFF
--- a/src/repositories/request-repository.ts
+++ b/src/repositories/request-repository.ts
@@ -6,7 +6,11 @@ import { logEvent } from '../logger/index.js'
 import { Config } from 'node-config-ts'
 import { logger } from '../logger/index.js'
 import { Utils } from '../utils.js'
-import { ServiceMetrics as Metrics, TimeableMetric, SinceField } from '@ceramicnetwork/observability'
+import {
+  ServiceMetrics as Metrics,
+  TimeableMetric,
+  SinceField,
+} from '@ceramicnetwork/observability'
 import { METRIC_NAMES } from '../settings.js'
 
 // How long we should keep recently anchored streams pinned on our local Ceramic node, to keep the
@@ -221,7 +225,7 @@ export class RequestRepository {
         pinned: fields.pinned,
         updatedAt: updatedAt,
       })
-      .whereIn('id', ids)
+      .where('id', 'in', connection.raw('SELECT * FROM UNNEST (?::uuid[])', [ids]))
 
     requests.map((request) => {
       logEvent.db({


### PR DESCRIPTION
Debated between two approaches: 
1. Limit amount of requests per stream so that the total amount of requests never exceeds some number. This prevents us from having to retrieve 65654 commits as well. The problem then shifts to: if we anchor 10 of the oldest requests for streamA, the next batch will pick up 10 more requests for streamA but streamA will be already anchored, so streamA will not be included in the batch and this will result in a possible emptier batch

2. I can circumvent this limit by using unnest as mohsin suggested in the comments of the discord message. This definitely works. But do we want to create a batch with >65654 requests (but 1024 streams)


I went with options 2. It is unlikely we will reach 65654 requests again, AND with the CAS w/o a ceramic node project, the loading problem does not exist. 