### PR TITLE
publish the created-to-success statistics - #PLAT-1200

### DIFF
--- a/src/repositories/request-repository.ts
+++ b/src/repositories/request-repository.ts
@@ -270,7 +270,7 @@ export class RequestRepository {
           // Record the requests we are processing, along with the time since they were marked as ready.
           const processing = new TimeableMetric(SinceField.UPDATED_AT)
           processing.recordAll(requests)
-          processing.publishStats(METRIC_NAMES.READY_PROCESSING)
+          processing.publishStats(METRIC_NAMES.READY_PROCESSING_MS)
           return requests
         },
         {

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -528,10 +528,12 @@ export class AnchorService {
 
       await trx.commit()
 
+      // record some metrics about the timing and count of anchors
       const completed = new TimeableMetric(SinceField.CREATED_AT)
       completed.recordAll(acceptedRequests)
-
+      completed.publishStats(METRIC_NAMES.CREATED_SUCCESS_MS)
       Metrics.count(METRIC_NAMES.ACCEPTED_REQUESTS, acceptedRequests.length)
+
       return persistedAnchorsCount
     } catch (err) {
       await trx.rollback()

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -23,7 +23,10 @@ export enum METRIC_NAMES {
   PIN_FAILED = 'pin_failed',
 
   // request that moves from ready -> processing
-  READY_PROCESSING = 'ready_processing',
+  READY_PROCESSING_MS = 'ready_processing_ms',
+
+  // request that moves from created -> success
+  CREATED_SUCCESS_MS = 'created_success_ms',
 
   // when a request is created, expired or completes
   REQUEST_CREATED = 'request_created',


### PR DESCRIPTION
# publish the created-to-success statistics - #PLAT-1200

## Description

publish the metric from created-to-success for each anchor (had gathered but neglected to publish it)

also rename with _MS suffix for clarity that these are in milliseconds

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ ] unit tests
- [ ] publishing of other metrics is working using the same call

## Definition of Done

Before submitting this PR, please make sure:

- [ ] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
