### PR TITLE
Feat/fill the origin CDB-2016

### DIFF
--- a/src/controllers/__tests__/request-controller.test.ts
+++ b/src/controllers/__tests__/request-controller.test.ts
@@ -142,14 +142,13 @@ describe('createRequest', () => {
       const createdRequest = await requestRepository.findByCid(cid)
       expect(createdRequest).toBeDefined()
       expect(createdRequest.cid).toEqual(cid.toString())
-      expect(createdRequest.origin).toEqual(origin)
       expect(createdRequest.status).toEqual(RequestStatus.PENDING)
       expect(createdRequest.streamId).toEqual(streamId.toString())
       expect(createdRequest.message).toEqual('Request is pending.')
       expect(createdRequest.timestamp.valueOf()).toEqual(timestamp.valueOf())
       expect(createdRequest.createdAt.valueOf()).toBeCloseTo(now.valueOf(), -1.4) // within ~12 ms
       expect(createdRequest.updatedAt.valueOf()).toBeCloseTo(now.valueOf(), -1.4) // within ~12 ms
-      expect(createdRequest.origin).toBeNull()
+      expect(createdRequest.origin).toEqual(origin)
     })
 
     test('timestamp is empty', async () => {

--- a/src/controllers/__tests__/request-controller.test.ts
+++ b/src/controllers/__tests__/request-controller.test.ts
@@ -119,7 +119,14 @@ describe('createRequest', () => {
       const cid = randomCID()
       const streamId = randomStreamID()
       const timestamp = new Date()
+      const origin = '203.0.113.195'
       const req = mockRequest({
+        headers: {
+          'X-Forwarded-For': [
+            ` ${origin}`,
+            `${origin}, 2001:db8:85a3:8d3:1319:8a2e:370:7348`
+          ]
+        },
         body: {
           cid: cid.toString(),
           streamId: streamId.toString(),
@@ -135,6 +142,7 @@ describe('createRequest', () => {
       const createdRequest = await requestRepository.findByCid(cid)
       expect(createdRequest).toBeDefined()
       expect(createdRequest.cid).toEqual(cid.toString())
+      expect(createdRequest.origin).toEqual(origin)
       expect(createdRequest.status).toEqual(RequestStatus.PENDING)
       expect(createdRequest.streamId).toEqual(streamId.toString())
       expect(createdRequest.message).toEqual('Request is pending.')

--- a/src/controllers/request-controller.ts
+++ b/src/controllers/request-controller.ts
@@ -90,6 +90,15 @@ export class RequestController {
 
       request = new Request()
       request.cid = cid.toString()
+
+      // Parsing according to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#parsing
+      let addresses: string
+      if (Array.isArray(req.headers['X-Forwarded-For'])) {
+        addresses = req.headers['X-Forwarded-For'].join(',')
+      } else {
+        addresses = req.headers['X-Forwarded-For']
+      }
+      request.origin = addresses[0]
       request.streamId = streamId.toString()
       request.status = RequestStatus.PENDING
       request.message = 'Request is pending.'

--- a/src/controllers/request-controller.ts
+++ b/src/controllers/request-controller.ts
@@ -98,7 +98,7 @@ export class RequestController {
       } else {
         addresses = req.headers['X-Forwarded-For']
       }
-      request.origin = addresses[0]
+      request.origin = addresses[0]?.trim()
       request.streamId = streamId.toString()
       request.status = RequestStatus.PENDING
       request.message = 'Request is pending.'

--- a/src/controllers/request-controller.ts
+++ b/src/controllers/request-controller.ts
@@ -98,7 +98,7 @@ export class RequestController {
       } else {
         addresses = req.headers['X-Forwarded-For']
       }
-      request.origin = addresses[0]?.trim()
+      request.origin = addresses.split(',')[0]?.trim()
       request.streamId = streamId.toString()
       request.status = RequestStatus.PENDING
       request.message = 'Request is pending.'

--- a/src/models/request.ts
+++ b/src/models/request.ts
@@ -21,7 +21,6 @@ export type IDBRequest = {
 
 export class Request {
   id: number
-  origin: string
   status: RequestStatus
   cid: string
   streamId: string

--- a/src/models/request.ts
+++ b/src/models/request.ts
@@ -21,6 +21,7 @@ export type IDBRequest = {
 
 export class Request {
   id: number
+  origin: string
   status: RequestStatus
   cid: string
   streamId: string


### PR DESCRIPTION
# Populate the request model with http request's origin IP address

## Description

The origin IP address is retrieved and parsed from `X-Forwarded-For` http header, according to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#parsing

## How Has This Been Tested?

- [X] Updated the test for request creation accordingly

## Definition of Done

Before submitting this PR, please make sure:

- [X] The work addresses the description and outcomes in the issue
- [X] I have added relevant tests for new or updated functionality
- [X] My code follows conventions, is well commented, and easy to understand
- [X] My code builds and tests pass without any errors or warnings
- [X] I have tagged the relevant reviewers

