### PR TITLE
Test useSmartContractAnchors

### DIFF
--- a/config/env/dev.json
+++ b/config/env/dev.json
@@ -10,6 +10,7 @@
   "minStreamCount": "@@MIN_STREAM_COUNT",
   "readyRetryIntervalMS": "@@READY_RETRY_INTERVAL_MS",
   "schedulerIntervalMS": "@@SCHEDULER_INTERVAL_MS",
+  "useSmartContractAnchors": "@@USE_SMART_CONTRACT_ANCHORS",
   "ipfsConfig": {
     "url": "@@IPFS_API_URL",
     "pubsubTopic": "@@IPFS_PUBSUB_TOPIC",
@@ -34,7 +35,8 @@
         "transactionTimeoutSecs": "@@ETH_TXN_TIMEOUT",
         "account": {
           "privateKey": "@@ETH_WALLET_PK"
-        }
+        },
+        "contractAddress": "@@ETH_CONTRACT_ADDRESS"
       }
     }
   },

--- a/config/env/prod.json
+++ b/config/env/prod.json
@@ -10,6 +10,7 @@
   "minStreamCount": "@@MIN_STREAM_COUNT",
   "readyRetryIntervalMS": "@@READY_RETRY_INTERVAL_MS",
   "schedulerIntervalMS": "@@SCHEDULER_INTERVAL_MS",
+  "useSmartContractAnchors": "@@USE_SMART_CONTRACT_ANCHORS",
   "ipfsConfig": {
     "url": "@@IPFS_API_URL",
     "pubsubTopic": "@@IPFS_PUBSUB_TOPIC",
@@ -34,7 +35,8 @@
         "transactionTimeoutSecs": "@@ETH_TXN_TIMEOUT",
         "account": {
           "privateKey": "@@ETH_WALLET_PK"
-        }
+        },
+        "contractAddress": "@@ETH_CONTRACT_ADDRESS"
       }
     }
   },

--- a/config/env/test.json
+++ b/config/env/test.json
@@ -22,7 +22,8 @@
         "transactionTimeoutSecs": 600,
         "account": {
           "privateKey": "0x06dd0990d19001c57eeea6d32e8fdeee40d3945962caf18c18c3930baa5a6ec9"
-        }
+        },
+        "contractAddress": "0xD3f84Cf6Be3DD0EB16dC89c972f7a27B441A39f2"
       }
     }
   },

--- a/config/env/test.json
+++ b/config/env/test.json
@@ -4,6 +4,7 @@
   "loadStreamTimeoutMs": 1000,
   "readyRetryIntervalMS": 10000,
   "schedulerIntervalMS": 10000,
+  "useSmartContractAnchors": true,
   "ceramic": {
     "validateRecords": false
   },


### PR DESCRIPTION
This PR turns on smart contract anchoring in the `test` environment only.

It also allows env vars to configure smart contract anchoring in other environments.