### PR TITLE
fix: make block info in anchor proof configurable

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -5,6 +5,7 @@
   "anchorControllerEnabled": false,
   "anchorLauncherUrl": "http://localhost:8001",
   "expirationPeriod": 5400000,
+  "includeBlockInfoInAnchorProof": true,
   "loadStreamTimeoutMs": 60000,
   "maxAnchoringDelayMS": 43200000,
   "merkleDepthLimit": 0,

--- a/config/env/dev.json
+++ b/config/env/dev.json
@@ -5,6 +5,7 @@
   "anchorControllerEnabled": "@@ANCHOR_CONTROLLER_ENABLED",
   "anchorLauncherUrl": "@@ANCHOR_LAUNCHER_URL",
   "expirationPeriod": "@@ANCHOR_EXPIRATION_PERIOD",
+  "includeBlockInfoInAnchorProof": "@@INCLUDE_BLOCK_INFO_IN_ANCHOR_PROOF",
   "loadStreamTimeoutMs": "@@LOAD_STREAM_TIMEOUT_MS",
   "maxAnchoringDelayMS": "@@MAX_ANCHORING_DELAY_MS",
   "merkleDepthLimit": "@@MERKLE_DEPTH_LIMIT",

--- a/config/env/prod.json
+++ b/config/env/prod.json
@@ -5,6 +5,7 @@
   "anchorControllerEnabled": "@@ANCHOR_CONTROLLER_ENABLED",
   "anchorLauncherUrl": "@@ANCHOR_LAUNCHER_URL",
   "expirationPeriod": "@@ANCHOR_EXPIRATION_PERIOD",
+  "includeBlockInfoInAnchorProof": "@@INCLUDE_BLOCK_INFO_IN_ANCHOR_PROOF",
   "loadStreamTimeoutMs": "@@LOAD_STREAM_TIMEOUT_MS",
   "maxAnchoringDelayMS": "@@MAX_ANCHORING_DELAY_MS",
   "merkleDepthLimit": "@@MERKLE_DEPTH_LIMIT",

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -391,13 +391,19 @@ export class AnchorService {
    */
   async _createIPFSProof(tx: Transaction, merkleRootCid: CID): Promise<CID> {
     const txHashCid = Utils.convertEthHashToCid(tx.txHash.slice(2))
-    const ipfsAnchorProof = {
-      blockNumber: tx.blockNumber,
-      blockTimestamp: tx.blockTimestamp,
+    let ipfsAnchorProof = {
       root: merkleRootCid,
       chainId: tx.chain,
       txHash: txHashCid,
     } as any
+
+    if (this.config.includeBlockInfoInAnchorProof) {
+      ipfsAnchorProof = {
+        blockNumber: tx.blockNumber,
+        blockTimestamp: tx.blockTimestamp,
+        ...ipfsAnchorProof,
+      }
+    }
 
     if (this.config.useSmartContractAnchors) ipfsAnchorProof.txType = CONTRACT_TX_TYPE
 


### PR DESCRIPTION
I haven't added config options to CAS before so not fully sure if I've covered all the changes. Please let me know if I've missed something.

Also, is this something I should add a unit test for? `anchor-service.test.ts` seemed like the right place, if so.