### PR TITLE
chore: Beautify IpfsService

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,8 +5,8 @@ import { Config } from 'node-config-ts'
 import type { Knex } from 'knex'
 import { logger } from './logger/index.js'
 import { CeramicAnchorServer } from './server.js'
-import { IpfsServiceImpl } from './services/ipfs-service.js'
-import type { IpfsService } from './services/ipfs-service.js'
+import { IpfsService } from './services/ipfs-service.js'
+import type { IIpfsService } from './services/ipfs-service.type.js'
 import { AnchorService } from './services/anchor-service.js'
 import { SchedulerService } from './services/scheduler-service.js'
 import { BlockchainService } from './services/blockchain/blockchain-service.js'
@@ -21,7 +21,10 @@ import { AnchorController } from './controllers/anchor-controller.js'
 import { RequestController } from './controllers/request-controller.js'
 import { ServiceInfoController } from './controllers/service-info-controller.js'
 import { EthereumBlockchainService } from './services/blockchain/ethereum/ethereum-blockchain-service.js'
-import { ServiceMetrics as Metrics, DEFAULT_TRACE_SAMPLE_RATIO } from '@ceramicnetwork/observability'
+import {
+  ServiceMetrics as Metrics,
+  DEFAULT_TRACE_SAMPLE_RATIO,
+} from '@ceramicnetwork/observability'
 import { version } from './version.js'
 import { cleanupConfigForLogging, normalizeConfig } from './normalize-config.util.js'
 import type { Injector } from 'typed-inject'
@@ -40,7 +43,7 @@ type ProvidedContext = {
   blockchainService: BlockchainService
   eventProducerService: EventProducerService
   ceramicService: CeramicService
-  ipfsService: IpfsService
+  ipfsService: IIpfsService
   schedulerService: SchedulerService
 } & DependenciesContext
 
@@ -67,13 +70,19 @@ export class CeramicAnchorApp {
       // register services
       .provideFactory('blockchainService', EthereumBlockchainService.make)
       .provideClass('eventProducerService', HTTPEventProducerService)
-      .provideClass('ipfsService', IpfsServiceImpl)
+      .provideClass('ipfsService', IpfsService)
       .provideClass('ceramicService', CeramicServiceImpl)
       .provideClass('anchorService', AnchorService)
       .provideClass('schedulerService', SchedulerService)
 
     try {
-      Metrics.start(this.config.metrics.collectorHost, 'cas-' + this.config.mode, DEFAULT_TRACE_SAMPLE_RATIO, null, false)
+      Metrics.start(
+        this.config.metrics.collectorHost,
+        'cas-' + this.config.mode,
+        DEFAULT_TRACE_SAMPLE_RATIO,
+        null,
+        false
+      )
       Metrics.count('HELLO', 1)
       logger.imp('Metrics exporter started')
     } catch (e) {

--- a/src/merkle/merkle-objects.ts
+++ b/src/merkle/merkle-objects.ts
@@ -6,7 +6,7 @@ import { CompareFunction, MergeFunction, MetadataFunction, Node, TreeMetadata } 
 import { Request } from '../models/request.js'
 
 import { logger } from '../logger/index.js'
-import { IpfsService } from '../services/ipfs-service.js'
+import type { IIpfsService } from '../services/ipfs-service.type.js'
 
 import { BloomFilter } from '@ceramicnetwork/wasm-bloom-filter'
 import { StreamID } from '@ceramicnetwork/streamid'
@@ -196,7 +196,7 @@ export class Candidate implements CIDHolder {
  * Implements IPFS merge CIDs
  */
 export class IpfsMerge implements MergeFunction<CIDHolder, TreeMetadata> {
-  constructor(private readonly ipfsService: IpfsService) {}
+  constructor(private readonly ipfsService: IIpfsService) {}
 
   async merge(
     left: Node<CIDHolder>,

--- a/src/models/request.ts
+++ b/src/models/request.ts
@@ -15,6 +15,7 @@ export class Request {
   pinned: boolean
   createdAt: Date
   updatedAt: Date
+  timestamp: Date
 }
 
 export interface RequestUpdateFields {

--- a/src/services/__tests__/anchor-service.test.ts
+++ b/src/services/__tests__/anchor-service.test.ts
@@ -8,6 +8,7 @@ import { clearTables, createDbConnection } from '../../db-connection.js'
 
 import { RequestRepository } from '../../repositories/request-repository.js'
 import { IpfsService } from '../ipfs-service.js'
+import type { IIpfsService } from '../ipfs-service.type.js'
 import { AnchorRepository, TABLE_NAME } from '../../repositories/anchor-repository.js'
 import { config, Config } from 'node-config-ts'
 import { CommitID, StreamID } from '@ceramicnetwork/streamid'
@@ -48,7 +49,7 @@ class FakeEthereumBlockchainService implements BlockchainService {
 
 async function createRequest(
   streamId: string,
-  ipfsService: IpfsService,
+  ipfsService: IIpfsService,
   requestRepository: RequestRepository,
   status: RequestStatus = RequestStatus.PENDING
 ): Promise<Request> {
@@ -117,7 +118,7 @@ const MIN_STREAM_COUNT = Math.floor(STREAM_LIMIT / 2)
 
 type Context = {
   config: Config
-  ipfsService: IpfsService
+  ipfsService: IIpfsService
   ceramicService: MockCeramicService
   eventProducerService: MockEventProducerService
   requestRepository: RequestRepository
@@ -126,7 +127,7 @@ type Context = {
 
 describe('anchor service', () => {
   jest.setTimeout(10000)
-  let ipfsService: IpfsService
+  let ipfsService: IIpfsService
   let ceramicService: MockCeramicService
   let connection: Knex
   let injector: Injector<Context>
@@ -135,7 +136,7 @@ describe('anchor service', () => {
   let eventProducerService: MockEventProducerService
 
   beforeAll(async () => {
-    const { IpfsServiceImpl } = await import('../ipfs-service.js')
+    const { IpfsService } = await import('../ipfs-service.js')
 
     connection = await createDbConnection()
     injector = createInjector()
@@ -152,7 +153,7 @@ describe('anchor service', () => {
       .provideClass('requestRepository', RequestRepository)
       .provideClass('transactionRepository', TransactionRepository)
       .provideClass('blockchainService', FakeEthereumBlockchainService)
-      .provideClass('ipfsService', IpfsServiceImpl)
+      .provideClass('ipfsService', IpfsService)
       .provideClass('ceramicService', MockCeramicService)
       .provideClass('eventProducerService', MockEventProducerService)
       .provideClass('anchorService', AnchorService)
@@ -284,7 +285,7 @@ describe('anchor service', () => {
 
     // Create pending requests
     for (let i = 0; i < numRequests; i++) {
-      const streamId = await randomStreamID()
+      const streamId = randomStreamID()
       const request = await createRequest(streamId.toString(), ipfsService, requestRepository)
       const commitId = CommitID.make(streamId, request.cid)
       const stream = createStream(streamId, [toCID(request.cid)])
@@ -636,8 +637,8 @@ describe('anchor service', () => {
   })
 
   test('Does not create anchor commits if stream has already been anchored for those requests', async () => {
-    const requestRepository = injector.resolve<RequestRepository>('requestRepository')
-    const anchorService = injector.resolve<AnchorService>('anchorService')
+    const requestRepository = injector.resolve('requestRepository')
+    const anchorService = injector.resolve('anchorService')
 
     const anchorLimit = 0 // 0 means infinity
     const numRequests = 5

--- a/src/services/__tests__/ipfs-service.test.ts
+++ b/src/services/__tests__/ipfs-service.test.ts
@@ -1,0 +1,116 @@
+import { jest, describe, test, expect } from '@jest/globals'
+import type { Config } from 'node-config-ts'
+import {
+  IPFS_GET_RETRIES,
+  IPFS_GET_TIMEOUT,
+  IPFS_PUT_TIMEOUT,
+  IpfsService,
+} from '../ipfs-service.js'
+import { MockIpfsClient, times } from '../../__tests__/test-utils.js'
+import type { IPFS } from 'ipfs-core-types'
+import type { AbortOptions } from '../abort-options.type.js'
+import type { CID } from 'multiformats/cid'
+import { DelayAbortedError, Utils } from '../../utils.js'
+
+const FAUX_CONFIG = {
+  ipfsConfig: {
+    pubsubTopic: '/faux',
+  },
+} as Config
+
+const RECORD = { hello: 'world' }
+
+let mockIpfsClient: MockIpfsClient
+let service: IpfsService
+
+beforeEach(() => {
+  mockIpfsClient = new MockIpfsClient()
+  service = new IpfsService(FAUX_CONFIG, mockIpfsClient as unknown as IPFS)
+})
+
+describe('storeRecord', () => {
+  test('store IPFS record', async () => {
+    const dagPutSpy = jest.spyOn(mockIpfsClient.dag, 'put')
+    await service.storeRecord(RECORD)
+    expect(dagPutSpy).toBeCalledWith(RECORD, { timeout: IPFS_PUT_TIMEOUT })
+  })
+  test('pass AbortSignal', async () => {
+    const dagPutSpy = jest.spyOn(mockIpfsClient.dag, 'put')
+    const abortController = new AbortController()
+    await service.storeRecord(RECORD, { signal: abortController.signal })
+    expect(dagPutSpy).toBeCalledWith(RECORD, {
+      signal: abortController.signal,
+      timeout: IPFS_PUT_TIMEOUT,
+    })
+  })
+})
+
+describe('retrieveRecord', () => {
+  test('cache record', async () => {
+    const cid = await service.storeRecord(RECORD)
+    const dagGetSpy = jest.spyOn(mockIpfsClient.dag, 'get')
+    expect(dagGetSpy).toBeCalledTimes(0)
+    await service.retrieveRecord(cid) // Call ipfs.dag.get
+    expect(dagGetSpy).toBeCalledTimes(1)
+    dagGetSpy.mockClear()
+    await service.retrieveRecord(cid) // Use cached value. Do not use ipfs.dag.get
+    expect(dagGetSpy).toBeCalledTimes(0)
+  })
+  test('cache record if path provided', async () => {
+    const cid = await service.storeRecord(RECORD)
+    const dagGetSpy = jest.spyOn(mockIpfsClient.dag, 'get')
+    expect(dagGetSpy).toBeCalledTimes(0)
+    await service.retrieveRecord(cid, { path: '/link' }) // Call ipfs.dag.get
+    expect(dagGetSpy).toBeCalledTimes(1)
+    dagGetSpy.mockClear()
+    await service.retrieveRecord(cid, { path: '/link' }) // Use cached value. Do not use ipfs.dag.get
+    expect(dagGetSpy).toBeCalledTimes(0)
+    dagGetSpy.mockClear()
+    await service.retrieveRecord(cid) // Without `path` it is a different value. Retrieve from ipfs.dag.get.
+    expect(dagGetSpy).toBeCalledTimes(1)
+  })
+  test('retry', async () => {
+    const cid = await service.storeRecord(RECORD)
+    const dagGetSpy = jest.spyOn(mockIpfsClient.dag, 'get')
+    times(IPFS_GET_RETRIES - 1).forEach(() => {
+      dagGetSpy.mockImplementationOnce(() => Promise.reject(new Error(`Nope`)))
+    })
+    await service.retrieveRecord(cid)
+    expect(dagGetSpy).toBeCalledTimes(IPFS_GET_RETRIES)
+    for (const i of times(IPFS_GET_RETRIES)) {
+      expect(dagGetSpy.mock.calls[i]).toEqual([cid, { timeout: IPFS_GET_TIMEOUT }])
+    }
+  })
+  test('retry: fail if attempts are exhausted', async () => {
+    const cid = await service.storeRecord(RECORD)
+    const dagGetSpy = jest.spyOn(mockIpfsClient.dag, 'get')
+    times(IPFS_GET_RETRIES).forEach(() => {
+      dagGetSpy.mockImplementationOnce(() => Promise.reject(new Error(`Nope`)))
+    })
+    await expect(service.retrieveRecord(cid)).rejects.toThrow(
+      /Failed to retrieve IPFS record for CID/
+    )
+  })
+  test('accept AbortSignal', async () => {
+    const abortController = new AbortController()
+    const cid = await service.storeRecord(RECORD)
+    const dagGetSpy = jest.spyOn(mockIpfsClient.dag, 'get')
+    // Simulate ipfs.dag.get call that throws when aborted
+    times(IPFS_GET_RETRIES - 1).forEach(() => {
+      dagGetSpy.mockImplementationOnce(async (cid: CID, options: AbortOptions) => {
+        await Utils.delay(10000, options.signal)
+      })
+    })
+    const retrieveRecordP = service.retrieveRecord(cid, { signal: abortController.signal })
+    abortController.abort()
+    // Delay is huge, so ipfs.dag.get is called just once
+    expect(dagGetSpy).toBeCalledTimes(1)
+    // Pass original AbortSignal to ipfs.dag.get
+    expect(dagGetSpy).toBeCalledWith(cid, {
+      timeout: IPFS_GET_TIMEOUT,
+      signal: abortController.signal,
+    })
+    // Do not retry if an exception is due to AbortSignal
+    await expect(retrieveRecordP).rejects.toThrow(DelayAbortedError)
+  })
+})

--- a/src/services/abort-options.type.ts
+++ b/src/services/abort-options.type.ts
@@ -1,0 +1,6 @@
+/**
+ * Contains AbortSignal.
+ */
+export interface AbortOptions {
+  signal?: AbortSignal
+}

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -14,10 +14,13 @@ import { AnchorRepository } from '../repositories/anchor-repository.js'
 import { RequestRepository } from '../repositories/request-repository.js'
 import { TransactionRepository } from '../repositories/transaction-repository.js'
 
-import { IpfsService } from './ipfs-service.js'
 import { EventProducerService } from './event-producer/event-producer-service.js'
 import { CeramicService } from './ceramic-service.js'
-import { ServiceMetrics as Metrics, TimeableMetric, SinceField } from '@ceramicnetwork/observability'
+import {
+  ServiceMetrics as Metrics,
+  TimeableMetric,
+  SinceField,
+} from '@ceramicnetwork/observability'
 import { METRIC_NAMES } from '../settings.js'
 import { BlockchainService } from './blockchain/blockchain-service.js'
 import { CommitID, StreamID } from '@ceramicnetwork/streamid'
@@ -31,6 +34,7 @@ import {
 } from '../merkle/merkle-objects.js'
 import { v4 as uuidv4 } from 'uuid'
 import type { Knex } from 'knex'
+import { IIpfsService } from './ipfs-service.type.js'
 
 const CONTRACT_TX_TYPE = 'f(bytes32)'
 
@@ -95,9 +99,11 @@ const logAnchorSummary = async (
   )
 
   Metrics.recordObjectFields('anchorBatch', anchorSummary)
-  Metrics.recordRatio('anchorBatch_failureRatio',
-              anchorSummary.failedRequestsCount,
-              anchorSummary.anchoredRequestsCount)  
+  Metrics.recordRatio(
+    'anchorBatch_failureRatio',
+    anchorSummary.failedRequestsCount,
+    anchorSummary.anchoredRequestsCount
+  )
 
   logEvent.anchor({
     type: 'anchorRequests',
@@ -127,7 +133,7 @@ export class AnchorService {
   constructor(
     private readonly blockchainService: BlockchainService,
     private readonly config: Config,
-    private readonly ipfsService: IpfsService,
+    private readonly ipfsService: IIpfsService,
     private readonly requestRepository: RequestRepository,
     private readonly transactionRepository: TransactionRepository,
     private readonly ceramicService: CeramicService,

--- a/src/services/ipfs-service.ts
+++ b/src/services/ipfs-service.ts
@@ -1,158 +1,136 @@
 import type { CID } from 'multiformats/cid'
 import LRUCache from 'lru-cache'
 import { create as createIpfsClient } from 'ipfs-http-client'
-import { Config } from 'node-config-ts'
+import type { Config } from 'node-config-ts'
 import { logger } from '../logger/index.js'
 import * as dagJose from 'dag-jose'
 import type { IPFS } from 'ipfs-core-types'
 import { AnchorCommit, toCID } from '@ceramicnetwork/common'
-import { StreamID } from '@ceramicnetwork/streamid'
+import type { StreamID } from '@ceramicnetwork/streamid'
 import { Utils } from '../utils.js'
 import * as http from 'http'
 import * as https from 'https'
 import { PubsubMessage } from '@ceramicnetwork/core'
+import type { IIpfsService, RetrieveRecordOptions } from './ipfs-service.type.js'
+import type { AbortOptions } from './abort-options.type.js'
+
 const { serialize, MsgType } = PubsubMessage
 
-const DEFAULT_GET_TIMEOUT = 30000 // 30 seconds
+export const IPFS_GET_RETRIES = 2
+export const IPFS_GET_TIMEOUT = 30000 // 30 seconds
 const MAX_CACHE_ENTRIES = 100
-const IPFS_PUT_TIMEOUT = 30 * 1000 // 30 seconds
+export const IPFS_PUT_TIMEOUT = 30 * 1000 // 30 seconds
 const PUBSUB_DELAY = 100
 
-export interface IpfsService {
-  /**
-   * Initialize the service
-   */
-  init(): Promise<void>
-
-  /**
-   * Gets the record by its CID value
-   * @param cid - CID value
-   */
-  retrieveRecord(cid: CID | string): Promise<any>
-
-  /**
-   * Sets the record and returns its CID
-   * @param record - Record value
-   */
-  storeRecord(record: any): Promise<CID>
-
-  /**
-   * Stores the anchor commit to ipfs and publishes an update pubsub message to the Ceramic pubsub topic
-   * @param anchorCommit - anchor commit
-   * @param streamId
-   */
-  publishAnchorCommit(anchorCommit: AnchorCommit, streamId: StreamID): Promise<CID>
-}
-
-const ipfsHttpAgent = (ipfsEndpoint: string) => {
+function buildHttpAgent(endpoint: string | undefined): http.Agent {
   const agentOptions = {
     keepAlive: false,
     maxSockets: Infinity,
   }
-  if (ipfsEndpoint.startsWith('https')) {
+  if (endpoint?.startsWith('https')) {
     return new https.Agent(agentOptions)
   } else {
     return new http.Agent(agentOptions)
   }
 }
 
-export class IpfsServiceImpl implements IpfsService {
-  private _ipfs: IPFS
-  private _cache: LRUCache<string, any>
+function buildIpfsClient(config: Config): IPFS {
+  return createIpfsClient({
+    url: config.ipfsConfig.url,
+    timeout: config.ipfsConfig.timeout,
+    ipld: {
+      codecs: [dagJose],
+    },
+    agent: buildHttpAgent(config.ipfsConfig.url),
+  })
+}
+
+export class IpfsService implements IIpfsService {
+  private readonly cache: LRUCache<string, any>
+  private readonly pubsubTopic: string
+  private readonly ipfs: IPFS
 
   static inject = ['config'] as const
 
-  constructor(private readonly config: Config) {}
+  constructor(config: Config, ipfs: IPFS = buildIpfsClient(config)) {
+    this.cache = new LRUCache<string, any>({ max: MAX_CACHE_ENTRIES })
+    this.ipfs = ipfs
+    this.pubsubTopic = config.ipfsConfig.pubsubTopic
+  }
 
   /**
    * Initialize the service
    */
   async init(): Promise<void> {
-    this._ipfs = createIpfsClient({
-      url: this.config.ipfsConfig.url,
-      timeout: this.config.ipfsConfig.timeout,
-      ipld: {
-        codecs: [dagJose],
-      },
-      agent: ipfsHttpAgent(this.config.ipfsConfig.url),
-    })
-
     // We have to subscribe to pubsub to keep ipfs connections alive.
     // TODO Remove this when the underlying ipfs issue is fixed
-    await this._ipfs.pubsub.subscribe(this.config.ipfsConfig.pubsubTopic, () => {
+    await this.ipfs.pubsub.subscribe(this.pubsubTopic, () => {
       /* do nothing */
     })
-
-    this._cache = new LRUCache<string, any>({ max: MAX_CACHE_ENTRIES })
   }
 
   /**
    * Gets the record by its CID value
    * @param cid - CID value
+   * @param options - May contain AbortSignal
    */
-  async retrieveRecord(cid: CID | string): Promise<any> {
-    let retryTimes = 2
+  async retrieveRecord<T = any>(
+    cid: CID | string,
+    options: RetrieveRecordOptions = {}
+  ): Promise<T> {
+    const cacheKey = `${cid}${options.path || ''}`
+    let retryTimes = IPFS_GET_RETRIES
     while (retryTimes > 0) {
       try {
-        let value = this._cache.get(cid.toString())
-        if (value != null) {
-          return value
+        const found = this.cache.get(cacheKey)
+        if (found) {
+          return found
         }
-        const record = await this._ipfs.dag.get(toCID(cid), {
-          timeout: DEFAULT_GET_TIMEOUT,
+        const record = await this.ipfs.dag.get(toCID(cid), {
+          path: options.path,
+          timeout: IPFS_GET_TIMEOUT,
+          signal: options.signal,
         })
-        logger.debug('Successfully retrieved ' + cid)
-
-        value = record.value
-        this._cache.set(cid.toString(), value)
-        return value
+        const value = record.value
+        logger.debug(`Successfully retrieved ${cacheKey}`)
+        this.cache.set(cacheKey, value)
+        return value as T
       } catch (e) {
-        logger.err('Cannot retrieve IPFS record for CID ' + cid.toString())
+        if (options.signal?.aborted) throw e
+        logger.err(`Cannot retrieve IPFS record for CID ${cacheKey}`)
         retryTimes--
       }
     }
-    throw new Error('Failed to retrieve IPFS record for CID ' + cid.toString())
+    throw new Error(`Failed to retrieve IPFS record for CID ${cacheKey}`)
   }
 
   /**
-   * Sets the record and returns its CID
-   * @param record - Record value
+   * Sets the record and returns its CID.
    */
-  async storeRecord(record: Record<string, unknown>): Promise<CID> {
-    let timeout: any
-
-    const putPromise = this._ipfs.dag.put(record).finally(() => {
-      clearTimeout(timeout)
-    })
-
-    const timeoutPromise = new Promise((resolve) => {
-      timeout = setTimeout(resolve, IPFS_PUT_TIMEOUT)
-    })
-
-    return await Promise.race([
-      putPromise,
-      timeoutPromise.then(() => {
-        throw new Error(`Timed out storing record in IPFS`)
-      }),
-    ])
+  storeRecord(record: Record<string, unknown>, options: AbortOptions = {}): Promise<CID> {
+    return this.ipfs.dag.put(record, { signal: options.signal, timeout: IPFS_PUT_TIMEOUT })
   }
 
   /**
-   * Stores the anchor commit to ipfs and publishes an update pubsub message to the Ceramic pubsub topic
+   * Stores `anchorCommit` to ipfs and publishes an update pubsub message to the Ceramic pubsub topic
    * @param anchorCommit - anchor commit
    * @param streamId
+   * @param options
    */
-  async publishAnchorCommit(anchorCommit: AnchorCommit, streamId: StreamID): Promise<CID> {
-    const anchorCid = await this.storeRecord(anchorCommit as any)
+  async publishAnchorCommit(
+    anchorCommit: AnchorCommit,
+    streamId: StreamID,
+    options: AbortOptions = {}
+  ): Promise<CID> {
+    const anchorCid = await this.storeRecord(anchorCommit as any, { signal: options.signal })
 
-    const updateMessage = {
+    const serializedMessage = serialize({
       typ: MsgType.UPDATE,
       stream: streamId,
       tip: anchorCid,
-    }
-    const serializedMessage = serialize(updateMessage as any)
+    })
 
-    await this._ipfs.pubsub.publish(this.config.ipfsConfig.pubsubTopic, serializedMessage)
+    await this.ipfs.pubsub.publish(this.pubsubTopic, serializedMessage, { signal: options.signal })
 
     // wait so that we don't flood the pubsub
     await Utils.delay(PUBSUB_DELAY)

--- a/src/services/ipfs-service.type.ts
+++ b/src/services/ipfs-service.type.ts
@@ -1,0 +1,41 @@
+import type { AnchorCommit } from '@ceramicnetwork/common'
+import type { StreamID } from '@ceramicnetwork/streamid'
+import type { CID } from 'multiformats/cid'
+import type { AbortOptions } from './abort-options.type.js'
+
+export type RetrieveRecordOptions = {
+  path?: string
+} & AbortOptions
+
+export interface IIpfsService {
+  /**
+   * Initialize the service
+   */
+  init(): Promise<void>
+
+  /**
+   * Gets the record by its CID value
+   * @param cid - CID value
+   * @param options - Can pass AbortSignal or IPLD `path`.
+   */
+  retrieveRecord<T = any>(cid: CID | string, options?: RetrieveRecordOptions): Promise<T>
+
+  /**
+   * Sets the record and returns its CID
+   * @param record - Record value
+   * @param options - Can pass AbortSignal
+   */
+  storeRecord(record: any, options?: AbortOptions): Promise<CID>
+
+  /**
+   * Stores the anchor commit to ipfs and publishes an update pubsub message to the Ceramic pubsub topic
+   * @param anchorCommit - anchor commit
+   * @param streamId
+   * @param options - Can pass AbortSignal
+   */
+  publishAnchorCommit(
+    anchorCommit: AnchorCommit,
+    streamId: StreamID,
+    options?: AbortOptions
+  ): Promise<CID>
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,21 +3,32 @@ import { create as createMultihash } from 'multiformats/hashes/digest'
 
 const KECCAK_256_CODE = 0x1b
 const ETH_TX_CODE = 0x93
+
+/**
+ * Thrown when `Utils.delay` gets aborted by AbortSignal.
+ */
+export class DelayAbortedError extends Error {
+  constructor() {
+    super(`Delay aborted`)
+  }
+}
+
 export class Utils {
   /**
-   * Flatten array of arrays
-   * @param arr - Array of arrays
-   */
-  static flattenArray(arr: any[]): any[] {
-    return arr.reduce((accumulator, value) => accumulator.concat(value), [])
-  }
-
-  /**
    * "sleeps" for the given number of milliseconds
-   * @param mills
    */
-  static async delay(mills: number): Promise<void> {
-    await new Promise<void>((resolve) => setTimeout(() => resolve(), mills))
+  static delay(mills: number, abortSignal?: AbortSignal): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(resolve, mills)
+      if (abortSignal) {
+        const done = () => {
+          clearTimeout(timeout)
+          reject(new DelayAbortedError())
+        }
+        if (abortSignal.aborted) done()
+        abortSignal.addEventListener('abort', done)
+      }
+    })
   }
 
   /**
@@ -36,10 +47,9 @@ export class Utils {
    * @param arr - Array of number
    */
   static averageArray(arr: number[]): number {
-
-    if (arr.length == 0) {
-        return 0
-    }    
+    if (arr.length === 0) {
+      return 0
+    }
 
     return arr.reduce((total, aNumber) => total + aNumber, 0) / arr.length
   }


### PR DESCRIPTION
Added:
- `IpfsService` as an implementation from `IIpfsService` as an interface live in different files
- `IpfsService` accepts `AbortSignal`
- `IpfsService` passes native IPFS-client timeouts
- `IpfsService::retrieveRecord` accepts `path` option to use IPLD traversal
- `Utils.delay` accepts `AbortSignal` too
- `IpfsService` has a test suite