### PR TITLE
fix: apply loadStream timeout to the multiquery request also

### DIFF
--- a/src/services/ceramic-service.ts
+++ b/src/services/ceramic-service.ts
@@ -19,7 +19,7 @@ const DEFAULT_LOAD_STREAM_TIMEOUT = 1000 * 60 // 1 minute
 const MULTIQUERY_SERVER_TIMEOUT = 1000 * 60 // 1 minute
 // 10 seconds more than server-side timeout so server-side timeout can fire first, which gives us a
 // more useful error message
-const MULTIQUERY_CLIENT_TIMEOUT = 1000 * 70 // 1 minute and 10 seconds
+const DEFAULT_MULTIQUERY_CLIENT_TIMEOUT = 1000 * 70 // 1 minute and 10 seconds
 const PIN_TIMEOUT = 1000 * 60 * 2 // 2 minutes
 
 export class CeramicServiceImpl implements CeramicService {
@@ -91,7 +91,7 @@ export class CeramicServiceImpl implements CeramicService {
       timeout = setTimeout(() => {
         logger.warn(`Timed out loading multiquery`)
         reject(new Error(`Timed out loading multiquery`))
-      }, MULTIQUERY_CLIENT_TIMEOUT)
+      }, this.config.loadStreamTimeoutMs || DEFAULT_MULTIQUERY_CLIENT_TIMEOUT)
     })
 
     return await Promise.race([queryPromise, timeoutPromise])


### PR DESCRIPTION
is this actually safe?  The multiqueries are expected to take longer than the regular loadStream since they can never just get the state from the state store, they always have to actually apply the log for the commits manually.  So this does seem like maybe we could get stuck with the multiquery always timing out and timing out again on retry.

my brain is too fried to think through this fully at the moment, but if we can convince ourselves this is safe, it could help speed up anchor batches even more