### PR TITLE
fix: don't pin when loading stream for anchor worker

### DIFF
--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -34,6 +34,7 @@ import {
 import { v4 as uuidv4 } from 'uuid'
 import type { Knex } from 'knex'
 import type { IIpfsService } from './ipfs-service.type.js'
+import { SyncOptions } from '@ceramicnetwork/common'
 
 const CONTRACT_TX_TYPE = 'f(bytes32)'
 
@@ -760,7 +761,12 @@ export class AnchorService {
     // First, load the current known stream state from the ceramic node
     let stream
     try {
-      stream = await ceramicService.loadStream(candidate.streamId)
+      stream = await ceramicService.loadStream(
+        candidate.streamId,
+        SyncOptions.PREFER_CACHE,
+        undefined,
+        false
+      )
     } catch (err) {
       logger.err(`Failed to load stream ${candidate.streamId.toString()}: ${err}`)
       Metrics.count(METRIC_NAMES.FAILED_STREAM, 1)


### PR DESCRIPTION
We'll still try to pin the stream during request creation in the API server