### PR TITLE
CAS Auth Fixes

### DIFF
--- a/auth/src/authorizers/default.ts
+++ b/auth/src/authorizers/default.ts
@@ -81,7 +81,7 @@ async function allowRegisteredDID(event: APIGatewayRequestAuthorizerEvent, callb
   if (result) {
     const did = result.didResolutionResult.didDocument?.id
     const nonce = result.payload?.nonce
-    const digest = result.payload?.body
+    const digest = result.payload?.digest
     if (!did) {
       console.error('Missing did')
     } else if (!nonce) {

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -18,11 +18,13 @@ function buildExpressMiddleware() {
     return function(req: Request, _res: Response, next: NextFunction) {
         if (req.headers) {
             if (req.headers['did'] && req.body) {
-                const digest = buildBodyDigest(req.headers['content-type'], req.body)
-                if (req.headers['digest'] == digest) {
-                  next()
-                } else {
-                  throw Error('Body digest verification failed')
+                if (Object.keys(req.body).length > 0) {
+                    const digest = buildBodyDigest(req.headers['content-type'], req.body)
+                    if (req.headers['digest'] == digest) {
+                      next()
+                    } else {
+                      throw Error('Body digest verification failed')
+                    }
                 }
             }
         }

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -21,14 +21,14 @@ function buildExpressMiddleware() {
                 if (Object.keys(req.body).length > 0) {
                     const digest = buildBodyDigest(req.headers['content-type'], req.body)
                     if (req.headers['digest'] == digest) {
-                      next()
+                      return next()
                     } else {
                       throw Error('Body digest verification failed')
                     }
                 }
             }
         }
-        next()
+        return next()
     }
 }
 


### PR DESCRIPTION
### Summary
I found a few issues with CAS auth in dev. After applying these fixes to a [temporary image](https://github.com/ceramicnetwork/ceramic-anchor-service/tree/temp/debug) I did not see any unrecognizable errors.

### Changes
- Get use `digest` property from signed payload instead of body (to match [how js-ceramic creates payload](https://github.com/ceramicnetwork/js-ceramic/blob/eb179830da3b5396794e85a5df374c7fc1590829/packages/core/src/anchor/auth/did-anchor-service-auth.ts#L49-L53))
- Check if `req.body` is an empty object in auth middleware (skip verification if so)
- Add return statements so `next` is not called twice in auth middleware