### PR TITLE
fix: get source ip as origin from auth lambda

### DIFF
--- a/auth/src/authorizers/default.ts
+++ b/auth/src/authorizers/default.ts
@@ -50,7 +50,10 @@ export const handler = async (event: APIGatewayRequestAuthorizerEvent, context, 
 
 function allowAll(event: APIGatewayRequestAuthorizerEvent, callback: any): any {
   const ip = event.requestContext.identity.sourceIp
-  return callback(null, generatePolicy(ip, {effect: 'Allow', resource: event.methodArn }))
+  const context = {
+    "sourceIp": ip
+  }
+  return callback(null, generatePolicy(ip, {effect: 'Allow', resource: event.methodArn }, ip, context))
 }
 
 async function allowPermissionedIPAddress(event: APIGatewayRequestAuthorizerEvent, callback: any): Promise<[boolean, any]> {
@@ -66,6 +69,7 @@ async function allowPermissionedIPAddress(event: APIGatewayRequestAuthorizerEven
 }
 
 async function allowRegisteredDID(event: APIGatewayRequestAuthorizerEvent, callback, jws: string): Promise<any> {
+  const ip = event.requestContext.identity.sourceIp
   let result: VerifyJWSResult | undefined
   try {
     result = await parseSignature(jws)
@@ -94,7 +98,8 @@ async function allowRegisteredDID(event: APIGatewayRequestAuthorizerEvent, callb
           if (data.did == did && data.nonce == nonce) {
             const context = {
               "did": did,
-              "digest": digest
+              "digest": digest,
+              "sourceIp": ip
             }
             return callback(null, generatePolicy(did, {effect: 'Allow', resource: event.methodArn}, did, context))
           }

--- a/src/controllers/request-controller.ts
+++ b/src/controllers/request-controller.ts
@@ -33,6 +33,8 @@ import { getMessage } from '../ancillary/throw-decoder.js'
 function parseOrigin(req: ExpReq): string {
   const didHeader = req.get('did')
   if (didHeader) return didHeader
+  const sourceIp = req.get('sourceIp')
+  if (sourceIp) return sourceIp
   let addresses = req.ip
   const xForwardedForHeader = req.get('X-Forwarded-For')
   if (xForwardedForHeader) {


### PR DESCRIPTION
## Description

Adds sourceIp header in authorizer lambda to be used in CAS API to when parsing request origin.

Requires https://github.com/3box/ceramic-infra/pull/681 to be deployed first for this to work.