### PR TITLE
feat: add logging and test for sourceip

### DIFF
--- a/src/controllers/__tests__/request-controller.test.ts
+++ b/src/controllers/__tests__/request-controller.test.ts
@@ -421,4 +421,30 @@ describe('createRequest', () => {
     expectPresent(createdRequest)
     expect(createdRequest.origin).toEqual(didHeader)
   })
+
+  test('accept sourceIp from header as origin', async () => {
+    const cid = randomCID()
+    const streamId = randomStreamID()
+    const timestamp = new Date()
+    const sourceIp = '101.0.0.7'
+    const req = mockRequest({
+      headers: {
+        'Content-type': 'application/json',
+        sourceIp: sourceIp,
+        'X-Forwarded-For': [`2001:db8:85a3:8d3:1319:8a2e:370:7348`],
+      },
+      body: {
+        cid: cid.toString(),
+        streamId: streamId.toString(),
+        timestamp: timestamp.toISOString(),
+      },
+    })
+    const res = mockResponse()
+    await controller.createRequest(req, res)
+    expect(res.status).toBeCalledWith(StatusCodes.CREATED)
+    const requestRepository = container.resolve('requestRepository')
+    const createdRequest = await requestRepository.findByCid(cid)
+    expectPresent(createdRequest)
+    expect(createdRequest.origin).toEqual(sourceIp)
+  })
 })

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -49,6 +49,9 @@ function buildExpressMiddleware() {
   morgan.token<ExpReq, ExpRes>('path', function (req): any {
     return req.path
   })
+  morgan.token<ExpReq, ExpRes>('sourceIp', function (req): any {
+    return req.get('sourceIp')
+  })
 
   const logger = loggerProvider.makeServiceLogger('http-access')
   return morgan(ACCESS_LOG_FMT, { stream: logger })


### PR DESCRIPTION
Include sourceIp in http access logs and add a test for getting origin from sourceIp.