### PR TITLE
Accept raw request body for application/vnd.ipld.car content-type

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ export class CeramicAnchorServer extends Server {
     this.app.set('trust proxy', true)
     this.app.use(bodyParser.json())
     this.app.use(bodyParser.urlencoded({ extended: true }))
+    this.app.use(bodyParser.raw({type: 'application/vnd.ipld.car'}))
     this.app.use(expressLoggers)
     if (config.requireAuth == true) {
       this.app.use(auth)


### PR DESCRIPTION
Ceramic sends car files as bytes in anchor requests' bodies and sets the content type to 'application/vnd.ipld.car'