### PR TITLE
record the source ip or did

### DIFF
--- a/src/controllers/request-controller.ts
+++ b/src/controllers/request-controller.ts
@@ -129,7 +129,7 @@ export class RequestController {
       }
 
       // Intentionally don't await the pinStream promise, let it happen in the background.
-      Metrics.count(METRIC_NAMES.ANCHOR_REQUESTED, 1, { ip_addr: req.ip })
+      Metrics.count(METRIC_NAMES.ANCHOR_REQUESTED, 1, { source: parseOrigin(req) })
 
       const request = new Request()
       request.cid = cid.toString()


### PR DESCRIPTION
# CAS activity by IP address is no longer accurate - #PLAT-1381

## Description

deployment of cas-auth changed the way ip addresses are recorded


we can use the new parseOrigin function to replace them (sometimes it is did, sometimes it is ip addr). 



## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x ] unit tests


## Definition of Done

Before submitting this PR, please make sure:

- [x ] The work addresses the description and outcomes in the issue

TBD - after this merges will update the grafana

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
