### PR TITLE
add the ip for gitcoin hirenode

### DIFF
--- a/auth/src/authorizers/ipAllowlist.ts
+++ b/auth/src/authorizers/ipAllowlist.ts
@@ -40,6 +40,7 @@ export const ALLOWED_IP_ADDRESSES: Record<string, string> = {
     "162.55.216.67": "Wetez",
     "34.236.75.99": "Gitcoin",
     "35.170.181.124": "Gitcoin",
+    "144.202.24.120": "Gitcoin via Hirenode",
     "64.225.91.133": "Disco.xyz",
     "143.198.245.21": "Disco.xyz",
     "137.184.244.223": "Disco.xyz",


### PR DESCRIPTION
# Ensure hirenode does not run into rate limits  - #PLAT-1410

## Description

We want to ensure Hirenode does not run into rate limits during the Gitcoin round.

Will merge this directly to main, deploy to prod cas-auth, then we can merge back to develop.