### PR TITLE
add context with source ip into permissioned ip address pathway

### DIFF
--- a/.github/workflows/ci-auth.yml
+++ b/.github/workflows/ci-auth.yml
@@ -27,7 +27,7 @@ jobs:
         name: Setup pnpm
         run: |
           npm install -g pnpm
-          pnpm install
+          pnpm install --no-frozen-lockfile
         working-directory: ./auth
       -
         name: Run unit tests

--- a/auth/src/authorizers/default.ts
+++ b/auth/src/authorizers/default.ts
@@ -63,8 +63,12 @@ function allowAll(event: APIGatewayRequestAuthorizerEvent, callback: any): any {
 async function allowPermissionedIPAddress(event: APIGatewayRequestAuthorizerEvent, callback: any): Promise<[boolean, any]> {
     const ip = event.requestContext.identity.sourceIp
     console.log('ip', ip)
+    
+    const context = {
+      "sourceIp": ip
+    }
     if (ALLOWED_IP_ADDRESSES[ip]) {
-      return [true, callback(null, generatePolicy(ip, {effect: 'Allow', resource: event.methodArn}, ip))]
+      return [true, callback(null, generatePolicy(ip, {effect: 'Allow', resource: event.methodArn}, ip, context))]
     } else {
       // Not an error, log and fall through.
       console.log('Not in allowed IP address list')


### PR DESCRIPTION
# parseOrigin needs sourceIP in prod - #CDB-2416

## Description

The change to include the sourceIp in a context field needed to also be made in the permissioned ip pathway. 

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x ] unit tests


## Definition of Done

Before submitting this PR, please make sure:

- [x ] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [x ] My code follows conventions, is well commented, and easy to understand
- [ x] My code builds and tests pass without any errors or warnings
- [ x] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ x] I have made corresponding changes to the documentation (already changed the metrics to pull this)
- [ ] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
