### PR TITLE
add context with source ip into permissioned ip address pathway (#1020)

### DIFF
--- a/.github/workflows/ci-auth.yml
+++ b/.github/workflows/ci-auth.yml
@@ -27,7 +27,7 @@ jobs:
         name: Setup pnpm
         run: |
           npm install -g pnpm
-          pnpm install --no-frozen-lockfile
+          pnpm install
         working-directory: ./auth
       -
         name: Run unit tests

--- a/.github/workflows/ci-auth.yml
+++ b/.github/workflows/ci-auth.yml
@@ -27,7 +27,7 @@ jobs:
         name: Setup pnpm
         run: |
           npm install -g pnpm
-          pnpm install
+          pnpm install --no-frozen-lockfile
         working-directory: ./auth
       -
         name: Run unit tests

--- a/auth/src/authorizers/default.ts
+++ b/auth/src/authorizers/default.ts
@@ -63,8 +63,12 @@ function allowAll(event: APIGatewayRequestAuthorizerEvent, callback: any): any {
 async function allowPermissionedIPAddress(event: APIGatewayRequestAuthorizerEvent, callback: any): Promise<[boolean, any]> {
     const ip = event.requestContext.identity.sourceIp
     console.log('ip', ip)
+    
+    const context = {
+      "sourceIp": ip
+    }
     if (ALLOWED_IP_ADDRESSES[ip]) {
-      return [true, callback(null, generatePolicy(ip, {effect: 'Allow', resource: event.methodArn}, ip))]
+      return [true, callback(null, generatePolicy(ip, {effect: 'Allow', resource: event.methodArn}, ip, context))]
     } else {
       // Not an error, log and fall through.
       console.log('Not in allowed IP address list')


### PR DESCRIPTION
cherry-pick 87b62b23361cf537b72bc45bb690c40d7dcc61e7
From https://github.com/ceramicnetwork/ceramic-anchor-service/pull/1020
* add context with source ip into permissioned ip address pathway

* see if no-frozen-lockfile fixes it

# parseOrigin needs sourceIP in prod - #CDB-2416

The change to include the sourceIp in a context field needed to also be made in the permissioned ip pathway.

## How Has This Been Tested?
Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

[x ] unit tests
[x] deploy to dev and verified that source_ip shows up in logs now for cas api

![image](https://user-images.githubusercontent.com/798887/234402320-b95d8036-42af-4bce-a376-b38886d9ded7.png)

