### PR TITLE
fix (api): Increase JSON payload size to 1MB

### DIFF
--- a/auth/src/handlers/api.ts
+++ b/auth/src/handlers/api.ts
@@ -20,6 +20,8 @@ const email = new SESService()
 const gateway = new ApiGateway()
 const metrics = new CloudMetrics()
 
+// limit increased from 100kb to accommodate CAR file payloads
+app.use(bodyParser.json({limit: '1mb'}))
 app.use(bodyParser.json())
 app.use(parseAsJson)
 function parseAsJson(req, res, next) {
@@ -74,7 +76,7 @@ function errorHandler (err, req, res, next) {
   }
   res.status(400).send({ error })
 }
- 
+
 export const handler = async (event, context) => {
   await db.init()
   await email.init()


### PR DESCRIPTION
# [Replace Me With Meaningful Name] - #[Issue]

## Description

Partner discovered issue when sending CAR files that resulted in an internal server error. Decided to increase JSON parsing size from default 100kb to 1MB to address the issue.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ ] Test A (e.g. Test A - New test that ... ran in local, docker, and dev unstable.)
- [ ] Test B

## Definition of Done

Before submitting this PR, please make sure:

- [ ] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
