### PR TITLE
chore: use DATABASE_URL for the db connection if set in tests

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -63,7 +63,8 @@
       "host": "localhost",
       "user": "root",
       "password": "root",
-      "port": 5432
+      "port": 5432,
+      "connectionString": ""
     },
     "debug": false,
     "migrations": {

--- a/config/env/test.json
+++ b/config/env/test.json
@@ -45,7 +45,8 @@
       "database": "test-db",
       "host": "localhost",
       "user": "test-user",
-      "port": 5432
+      "port": 5432,
+      "connectionString": "@@DATABASE_URL"
     },
     "debug": false,
     "migrations": {

--- a/src/db-connection.ts
+++ b/src/db-connection.ts
@@ -41,7 +41,13 @@ async function runMigrations(connection: Knex) {
 
 export async function createDbConnection(dbConfig: Db = config.db): Promise<Knex> {
   const knexConfig: Knex.Config = {
-    ...dbConfig,
+    client: dbConfig.client,
+    connection: dbConfig.connection.connectionString
+      ? dbConfig.connection.connectionString
+      : dbConfig.connection,
+    debug: dbConfig.debug,
+    migrations: dbConfig.migrations,
+
     // In our DB, identifiers have snake case formatting while in our code identifiers have camel case formatting.
     // We use the following transformers so we can always use camel case formatting in our code.
 

--- a/src/db-connection.ts
+++ b/src/db-connection.ts
@@ -42,9 +42,7 @@ async function runMigrations(connection: Knex) {
 export async function createDbConnection(dbConfig: Db = config.db): Promise<Knex> {
   const knexConfig: Knex.Config = {
     client: dbConfig.client,
-    connection: dbConfig.connection.connectionString
-      ? dbConfig.connection.connectionString
-      : dbConfig.connection,
+    connection: dbConfig.connection.connectionString || dbConfig.connection,
     debug: dbConfig.debug,
     migrations: dbConfig.migrations,
 


### PR DESCRIPTION
Currently if you would like to use a local db for tests, it has to have a specific configuration (test-db, test-user, etc. Now you can use the db url you provided with any configuration you want. 