### PR TITLE
chore: Update message for a replaced anchor

### DIFF
--- a/src/repositories/__tests__/request-repository.test.ts
+++ b/src/repositories/__tests__/request-repository.test.ts
@@ -846,6 +846,7 @@ describe('request repository test', () => {
         const retrieved = await requestRepository.findByCid(r.cid)
         expectPresent(retrieved)
         expect(retrieved.status).toEqual(RequestStatus.REPLACED)
+        expect(retrieved.message).toEqual(`Replaced by ${last.cid}`)
       }
       // Last request should be marked PENDING still
       const lastRetrieved = await requestRepository.findByCid(last.cid)

--- a/src/repositories/request-repository.ts
+++ b/src/repositories/request-repository.ts
@@ -458,7 +458,7 @@ export class RequestRepository {
       .where({ origin: request.origin, streamId: request.streamId })
       .andWhere({ status: RequestStatus.PENDING })
       .andWhere('timestamp', '<', date.encode(request.timestamp))
-      .update({ status: RequestStatus.REPLACED })
+      .update({ status: RequestStatus.REPLACED, message: `Replaced by ${request.cid}` })
   }
 
   /**


### PR DESCRIPTION
To `Replaced by ${cid of more recent commit}`