### PR TITLE
chore: Log an incoming request properly

### DIFF
--- a/src/ancillary/anchor-request-params-parser.ts
+++ b/src/ancillary/anchor-request-params-parser.ts
@@ -23,6 +23,8 @@ import {
   isLeft,
   decode,
   validate,
+  type,
+  union,
   type TypeOf,
   type Decoder,
   type Validation,
@@ -49,6 +51,13 @@ const RequestAnchorParamsV2Root = strict({
   tip: cid,
 })
 
+export const RequestAnchorParamsV2Codec = type({
+  streamId: streamIdAsString,
+  timestamp: date,
+  cid: cidAsString,
+  genesisFields: GenesisFields,
+})
+
 export type RequestAnchorParamsV2 = {
   streamId: StreamID
   timestamp: Date
@@ -57,6 +66,8 @@ export type RequestAnchorParamsV2 = {
 }
 
 export type RequestAnchorParams = RequestAnchorParamsV1 | RequestAnchorParamsV2
+
+export const RequestAnchorParamsCodec = union([RequestAnchorParamsV1, RequestAnchorParamsV2Codec])
 
 const DAG_JOSE_CODE = 133
 const DAG_CBOR_CODE = 113

--- a/src/ancillary/anchor-request-params-parser.ts
+++ b/src/ancillary/anchor-request-params-parser.ts
@@ -1,6 +1,5 @@
 import type { Request as ExpReq } from 'express'
 import type { CID } from 'multiformats/cid'
-import type { StreamID } from '@ceramicnetwork/streamid'
 import { CARFactory, type CAR } from 'cartonne'
 import { ServiceMetrics as Metrics } from '@ceramicnetwork/observability'
 import { METRIC_NAMES } from '../settings.js'
@@ -51,23 +50,24 @@ const RequestAnchorParamsV2Root = strict({
   tip: cid,
 })
 
-export const RequestAnchorParamsV2Codec = type({
+/**
+ * Used to encode request params for logging purposes
+ */
+export const RequestAnchorParamsV2 = type({
   streamId: streamIdAsString,
   timestamp: date,
   cid: cidAsString,
   genesisFields: GenesisFields,
 })
 
-export type RequestAnchorParamsV2 = {
-  streamId: StreamID
-  timestamp: Date
-  cid: CID
-  genesisFields: GenesisFields
-}
+export type RequestAnchorParamsV2 = TypeOf<typeof RequestAnchorParamsV2>
 
 export type RequestAnchorParams = RequestAnchorParamsV1 | RequestAnchorParamsV2
 
-export const RequestAnchorParamsCodec = union([RequestAnchorParamsV1, RequestAnchorParamsV2Codec])
+/**
+ * Encode request params for logging purposes.
+ */
+export const RequestAnchorParamsCodec = union([RequestAnchorParamsV1, RequestAnchorParamsV2])
 
 const DAG_JOSE_CODE = 133
 const DAG_CBOR_CODE = 113

--- a/src/controllers/request-controller.ts
+++ b/src/controllers/request-controller.ts
@@ -11,6 +11,7 @@ import { METRIC_NAMES } from '../settings.js'
 import {
   AnchorRequestParamsParser,
   RequestAnchorParams,
+  RequestAnchorParamsCodec,
 } from '../ancillary/anchor-request-params-parser.js'
 import bodyParser from 'body-parser'
 import type { RequestService } from '../services/request-service.js'
@@ -94,8 +95,6 @@ export class RequestController {
   async createRequest(req: ExpReq, res: ExpRes): Promise<ExpRes<any>> {
     const origin = parseOrigin(req)
 
-    logger.debug(`Create request ${JSON.stringify(req.body)}`)
-
     const validation = this.anchorRequestParamsParser.parse(req)
 
     if (isLeft(validation)) {
@@ -107,6 +106,8 @@ export class RequestController {
       })
     }
     const requestParams = validation.right
+
+    logger.debug(`Create request ${JSON.stringify(RequestAnchorParamsCodec.encode(requestParams))}`)
 
     try {
       const found = await this.requestService.findByCid(requestParams.cid)


### PR DESCRIPTION
Log the necessary fields.

FYI The failure is due to a version update in open zeppelin contracts repository. Fixed in https://github.com/ceramicnetwork/ceramic-anchor-service/pull/1096/commits/e41a479b0c8a463a2dc238b3a23436df10ba4650 as part of https://github.com/ceramicnetwork/ceramic-anchor-service/pull/1096