### PR TITLE
use the new observability package for consistent naming

### DIFF
--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -20,7 +20,7 @@ endif
 SHELL = /bin/bash
 
 build:
-	forge build --use 0.8.17
+	forge build
 	ls -lah out/
 t:
 	forge test -vvvvv
@@ -36,6 +36,6 @@ anchor:
 	cast send --private-key ${ETH_WALLET_PK} ${CONTRACT_ADDRESS} "anchorDagCbor(bytes32)" "0x3078300000000000000000000000000000000000000000000000000000000000" --legacy
 installDeps:
 	forge install foundry-rs/forge-std --no-git
-	forge install openzeppelin/openzeppelin-contracts --no-git
+	forge install openzeppelin/openzeppelin-contracts@v4.9.2 --no-git
 clean:
 	rm -rf cache/ out/ lib/

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,6 +1,7 @@
-[default]
+[profile.default]
 src = 'src'
 out = 'out'
 libs = ['lib']
+solc_version = '0.8.17'
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@ceramicnetwork/common": "^2.28.0-rc.0",
     "@ceramicnetwork/core": "^2.35.0-rc.0",
     "@ceramicnetwork/logger": "^2.5.0",
-    "@ceramicnetwork/observability": "^1.2.0",
+    "@ceramicnetwork/observability": "^1.4.0",
     "@ceramicnetwork/streamid": "^2.15.0-rc.0",
     "@ceramicnetwork/wasm-bloom-filter": "^0.1.0",
     "@overnightjs/core": "^1.7.6",


### PR DESCRIPTION
# Update Observability package to fix metric names - #PLAT-1526
## Description

So, we need to update the observability package (there was an issue of prometheus no longer converting : chars to _ taht messes up our historical metrics - this converts to _ in all cases) to 1.4.0

also cleaning out .swp files

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ ] Unit tests - but the build is failing

## Definition of Done

Before submitting this PR, please make sure:

- [ ] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
