### PR TITLE
update the observability package for consistent metric naming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@ceramicnetwork/common": "^2.28.0-rc.0",
         "@ceramicnetwork/core": "^2.35.0-rc.0",
         "@ceramicnetwork/logger": "^2.5.0",
-        "@ceramicnetwork/observability": "^1.2.0",
+        "@ceramicnetwork/observability": "^1.4.0",
         "@ceramicnetwork/streamid": "^2.15.0-rc.0",
         "@ceramicnetwork/wasm-bloom-filter": "^0.1.0",
         "@overnightjs/core": "^1.7.6",
@@ -3845,13 +3845,14 @@
       }
     },
     "node_modules/@ceramicnetwork/observability": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/observability/-/observability-1.2.0.tgz",
-      "integrity": "sha512-Xpnz2y2+SNiqTYok+BgkzVP8wGaKrqNjInHWUwG8ggYwWNSIZeuRzcIojIcCc/O6Huza7BUw+ubXSBoMkP/KRA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/observability/-/observability-1.4.0.tgz",
+      "integrity": "sha512-xiR4MZFy06489NRvrfaacmlwoZYkwn6pE3X/NRx9ATTr1hyCUK5wd8AjQrbe8Y6u1A+Vj5CkuxM0SDgZ92w93g==",
       "dependencies": {
         "@jest/globals": "^29.5.0",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.34.0",
+        "@opentelemetry/exporter-prometheus": "^0.40.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.34.0",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/sdk-metrics": "^1.8.0",
@@ -6770,6 +6771,59 @@
         "node": ">=14"
       }
     },
+    "node_modules/@opentelemetry/exporter-prometheus": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.40.0.tgz",
+      "integrity": "sha512-doiaj7T2NTrSfN/Lbyds8ULjZ9J1PWZHoCy48inMtQ6qdA5WPtwxlL0DLG4v1Ztsdd6Q3mi6/KRlG8uPFMhzdA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/resources": "1.14.0",
+        "@opentelemetry/sdk-metrics": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus/node_modules/@opentelemetry/core": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus/node_modules/@opentelemetry/resources": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
+      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
       "version": "0.34.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.34.0.tgz",
@@ -6943,12 +6997,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.13.0.tgz",
-      "integrity": "sha512-MOjZX6AnSOqLliCcZUrb+DQKjAWXBiGeICGbHAGe5w0BB18PJIeIo995lO5JSaFfHpmUMgJButTPfJJD27W3Vg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.14.0.tgz",
+      "integrity": "sha512-F0JXmLqT4LmsaiaE28fl0qMtc5w0YuMWTHt1hnANTNX8hxW4IKSv9+wrYG7BZd61HEbPm032Re7fXyzzNA6nIw==",
       "dependencies": {
-        "@opentelemetry/core": "1.13.0",
-        "@opentelemetry/resources": "1.13.0",
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/resources": "1.14.0",
         "lodash.merge": "4.6.2"
       },
       "engines": {
@@ -6959,17 +7013,40 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.13.0.tgz",
-      "integrity": "sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.13.0"
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
+      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
@@ -29628,13 +29705,14 @@
       }
     },
     "@ceramicnetwork/observability": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/observability/-/observability-1.2.0.tgz",
-      "integrity": "sha512-Xpnz2y2+SNiqTYok+BgkzVP8wGaKrqNjInHWUwG8ggYwWNSIZeuRzcIojIcCc/O6Huza7BUw+ubXSBoMkP/KRA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/observability/-/observability-1.4.0.tgz",
+      "integrity": "sha512-xiR4MZFy06489NRvrfaacmlwoZYkwn6pE3X/NRx9ATTr1hyCUK5wd8AjQrbe8Y6u1A+Vj5CkuxM0SDgZ92w93g==",
       "requires": {
         "@jest/globals": "^29.5.0",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.34.0",
+        "@opentelemetry/exporter-prometheus": "^0.40.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.34.0",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/sdk-metrics": "^1.8.0",
@@ -31826,6 +31904,40 @@
         }
       }
     },
+    "@opentelemetry/exporter-prometheus": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.40.0.tgz",
+      "integrity": "sha512-doiaj7T2NTrSfN/Lbyds8ULjZ9J1PWZHoCy48inMtQ6qdA5WPtwxlL0DLG4v1Ztsdd6Q3mi6/KRlG8uPFMhzdA==",
+      "requires": {
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/resources": "1.14.0",
+        "@opentelemetry/sdk-metrics": "1.14.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+          "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.14.0"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
+          "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
+          "requires": {
+            "@opentelemetry/core": "1.14.0",
+            "@opentelemetry/semantic-conventions": "1.14.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+          "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug=="
+        }
+      }
+    },
     "@opentelemetry/exporter-trace-otlp-http": {
       "version": "0.34.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.34.0.tgz",
@@ -31939,22 +32051,36 @@
       }
     },
     "@opentelemetry/sdk-metrics": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.13.0.tgz",
-      "integrity": "sha512-MOjZX6AnSOqLliCcZUrb+DQKjAWXBiGeICGbHAGe5w0BB18PJIeIo995lO5JSaFfHpmUMgJButTPfJJD27W3Vg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.14.0.tgz",
+      "integrity": "sha512-F0JXmLqT4LmsaiaE28fl0qMtc5w0YuMWTHt1hnANTNX8hxW4IKSv9+wrYG7BZd61HEbPm032Re7fXyzzNA6nIw==",
       "requires": {
-        "@opentelemetry/core": "1.13.0",
-        "@opentelemetry/resources": "1.13.0",
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/resources": "1.14.0",
         "lodash.merge": "4.6.2"
       },
       "dependencies": {
         "@opentelemetry/core": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.13.0.tgz",
-          "integrity": "sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==",
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+          "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
           "requires": {
-            "@opentelemetry/semantic-conventions": "1.13.0"
+            "@opentelemetry/semantic-conventions": "1.14.0"
           }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
+          "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
+          "requires": {
+            "@opentelemetry/core": "1.14.0",
+            "@opentelemetry/semantic-conventions": "1.14.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+          "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@ceramicnetwork/common": "^2.28.0-rc.0",
     "@ceramicnetwork/core": "^2.35.0-rc.0",
     "@ceramicnetwork/logger": "^2.5.0",
-    "@ceramicnetwork/observability": "^1.2.0",
+    "@ceramicnetwork/observability": "^1.4.0",
     "@ceramicnetwork/streamid": "^2.15.0-rc.0",
     "@ceramicnetwork/wasm-bloom-filter": "^0.1.0",
     "@overnightjs/core": "^1.7.6",


### PR DESCRIPTION
# Update Observability package to fix metric names - #PLAT-1526
## Description

So, we need to update the observability package (there was an issue of prometheus no longer converting : chars to _ taht messes up our historical metrics - this converts to _ in all cases) to 1.4.0

also cleaning out .swp files

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ ] Unit tests

## Definition of Done

Before submitting this PR, please make sure:

- [x ] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
