### PR TITLE
fix: do not assume default sqs queue url

### DIFF
--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -160,7 +160,7 @@ export class AnchorService {
   ) {
     this.merkleDepthLimit = config.merkleDepthLimit
     this.useSmartContractAnchors = config.useSmartContractAnchors
-    this.useQueueBatches = config.queue.sqsQueueUrl !== ''
+    this.useQueueBatches = !config.queue.sqsQueueUrl
 
     const minStreamCount = Number(config.minStreamCount)
     this.maxStreamLimit = this.merkleDepthLimit > 0 ? Math.pow(2, this.merkleDepthLimit) : 0

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -160,7 +160,7 @@ export class AnchorService {
   ) {
     this.merkleDepthLimit = config.merkleDepthLimit
     this.useSmartContractAnchors = config.useSmartContractAnchors
-    this.useQueueBatches = !config.queue.sqsQueueUrl
+    this.useQueueBatches = Boolean(config.queue.sqsQueueUrl)
 
     const minStreamCount = Number(config.minStreamCount)
     this.maxStreamLimit = this.merkleDepthLimit > 0 ? Math.pow(2, this.merkleDepthLimit) : 0


### PR DESCRIPTION
It is very weird that in kubernetes the default config does not populate sqsQueueUrl