### PR TITLE
log cas writes as well as issue a metric

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -115,7 +115,7 @@ export class CeramicAnchorApp {
     try {
       Metrics.start(
         this.config.metrics.collectorHost,
-        'cas-' + this.mode,
+        'cas_' + this.mode,
         DEFAULT_TRACE_SAMPLE_RATIO,
         null,
         false
@@ -123,6 +123,7 @@ export class CeramicAnchorApp {
       Metrics.count('HELLO', 1)
       logger.imp('Metrics exporter started')
     } catch (e: any) {
+      logger.imp('ERROR: Metrics exporter failed to start. Continuing anyway.')
       logger.err(e)
       // start anchor service even if metrics threw an error
     }

--- a/src/services/request-service.ts
+++ b/src/services/request-service.ts
@@ -1,6 +1,7 @@
 import type { CID } from 'multiformats/cid'
 import { ServiceMetrics as Metrics } from '@ceramicnetwork/observability'
 import { METRIC_NAMES } from '../settings.js'
+import { logger } from '../logger/index.js'
 import type { RequestRepository } from '../repositories/request-repository.js'
 import type { RequestPresentationService } from './request-presentation-service.js'
 import type { RequestAnchorParams } from '../ancillary/anchor-request-params-parser.js'
@@ -98,6 +99,7 @@ export class RequestService {
       family: genesisFields?.family,
       model: genesisFields?.model,
     })
+    logger.info(`Write requested: ${request.cid}`)
 
     return this.requestPresentationService.body(storedRequest)
   }

--- a/src/services/request-service.ts
+++ b/src/services/request-service.ts
@@ -99,7 +99,7 @@ export class RequestService {
       family: genesisFields?.family,
       model: genesisFields?.model,
     })
-    logger.info(`Write requested: ${request.cid}`)
+    logger.log(`Write requested: ${request.cid}`)
 
     return this.requestPresentationService.body(storedRequest)
   }

--- a/src/services/request-service.ts
+++ b/src/services/request-service.ts
@@ -99,7 +99,7 @@ export class RequestService {
       family: genesisFields?.family,
       model: genesisFields?.model,
     })
-    logger.log(`Write requested: ${request.cid}`)
+    logger.debug(`Write requested: ${request.cid}`)
 
     return this.requestPresentationService.body(storedRequest)
   }


### PR DESCRIPTION
# Log CAS writes - #PLAT-1458

## Description

This is a small PR that does 2 things:

1) changes the name from 'cas-[mode]' to 'cas_[mode]', because previously the '-' char was being auto-converted to an underscore, but now its not clear if that will happen or not.  So setting it explicitly to underscore to avoid possible name-change issues.

2) adds a log as well as metric to see if the createOrUpdate function is called as expected.  This will also give us a second check on the metrics which are a key KPI

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x] Unit tests

