### PR TITLE
fix: Store bytes to S3

### DIFF
--- a/src/services/merkle-car-service.ts
+++ b/src/services/merkle-car-service.ts
@@ -80,7 +80,7 @@ export class S3MerkleCarService implements IMerkleCarService {
   async storeCarFile(anchorProofCID: CID, car: CAR): Promise<void> {
     const key = anchorProofCID.toString()
     this.cache.set(key, car)
-    await this.s3store.put(key, car.bytes)
+    await this.s3store.put(key, Buffer.from(car.bytes))
   }
 
   async retrieveCarFile(anchorProofCID: CID): Promise<CAR | null> {


### PR DESCRIPTION
I fucked up. We try to store `Uint8Array` to S3 which [gets turned into String](https://github.com/loune/s3leveldown/blob/master/s3leveldown.js#L240) of numbers like `58,62,101,114, ...`, like what happens when you do `String(uint8array)`. The PR amends that.