### PR TITLE
feat: stop continual anchoring if we receive an empty batch

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -13,6 +13,7 @@
   "readyRetryIntervalMS": 300000,
   "requireAuth": false,
   "schedulerIntervalMS": 300000,
+  "schedulerStopAfterFail": false,
   "carStorage": {
     "mode": "inmemory",
     "s3BucketName": "myS3Bucket"

--- a/config/default.json
+++ b/config/default.json
@@ -13,7 +13,7 @@
   "readyRetryIntervalMS": 300000,
   "requireAuth": false,
   "schedulerIntervalMS": 300000,
-  "schedulerStopAfterFail": false,
+  "schedulerStopAfterNoOp": false,
   "carStorage": {
     "mode": "inmemory",
     "s3BucketName": "myS3Bucket"

--- a/config/default.json
+++ b/config/default.json
@@ -75,8 +75,6 @@
     "type": "sqs",
     "awsRegion": "us-east-1",
     "sqsQueueUrl": "",
-    "pollingIntervalMS": 10000,
-    "maxAttemptsToRetrieveMessages": 3,
     "maxTimeToHoldMessageSec": 21600,
     "waitTimeForMessageSec": 0
   }

--- a/config/env/dev.json
+++ b/config/env/dev.json
@@ -13,6 +13,7 @@
   "readyRetryIntervalMS": "@@READY_RETRY_INTERVAL_MS",
   "requireAuth": "@@REQUIRE_AUTH",
   "schedulerIntervalMS": "@@SCHEDULER_INTERVAL_MS",
+  "schedulerStopAfterFail": "@@SCHEDULER_STOP_AFTER_FAIL",
   "carStorage": {
     "mode": "@@MERKLE_CAR_STORAGE_MODE",
     "s3BucketName": "@@S3_BUCKET_NAME"

--- a/config/env/dev.json
+++ b/config/env/dev.json
@@ -70,8 +70,6 @@
     "type": "sqs",
     "awsRegion": "@@AWS_REGION",
     "sqsQueueUrl": "@@SQS_QUEUE_URL",
-    "pollingIntervalMS": "@@QUEUE_POLLING_INTERVAL_MS",
-    "maxAttemptsToRetrieveMessages": "@@QUEUE_MAX_ATTEMPTS_TO_RETRIEVE_MESSAGES",
     "maxTimeToHoldMessageSec": "@@MAX_TIME_TO_HOLD_MESSAGE_SEC",
     "waitTimeForMessageSec": "@@WAIT_TIME_FOR_MESSAGE_SEC"
   }

--- a/config/env/dev.json
+++ b/config/env/dev.json
@@ -13,7 +13,7 @@
   "readyRetryIntervalMS": "@@READY_RETRY_INTERVAL_MS",
   "requireAuth": "@@REQUIRE_AUTH",
   "schedulerIntervalMS": "@@SCHEDULER_INTERVAL_MS",
-  "schedulerStopAfterFail": "@@SCHEDULER_STOP_AFTER_FAIL",
+  "schedulerStopAfterNoOp": "@@SCHEDULER_STOP_AFTER_NO_OP",
   "carStorage": {
     "mode": "@@MERKLE_CAR_STORAGE_MODE",
     "s3BucketName": "@@S3_BUCKET_NAME"

--- a/config/env/prod.json
+++ b/config/env/prod.json
@@ -13,6 +13,7 @@
   "readyRetryIntervalMS": "@@READY_RETRY_INTERVAL_MS",
   "requireAuth": "@@REQUIRE_AUTH",
   "schedulerIntervalMS": "@@SCHEDULER_INTERVAL_MS",
+  "schedulerStopAfterFail": "@@SCHEDULER_STOP_AFTER_FAIL",
   "carStorage": {
     "mode": "@@MERKLE_CAR_STORAGE_MODE",
     "s3BucketName": "@@S3_BUCKET_NAME"

--- a/config/env/prod.json
+++ b/config/env/prod.json
@@ -70,8 +70,6 @@
     "type": "sqs",
     "awsRegion": "@@AWS_REGION",
     "sqsQueueUrl": "@@SQS_QUEUE_URL",
-    "pollingIntervalMS": "@@QUEUE_POLLING_INTERVAL_MS",
-    "maxAttemptsToRetrieveMessages": "@@QUEUE_MAX_ATTEMPTS_TO_RETRIEVE_MESSAGES",
     "maxTimeToHoldMessageSec": "@@MAX_TIME_TO_HOLD_MESSAGE_SEC",
     "waitTimeForMessageSec": "@@WAIT_TIME_FOR_MESSAGE_SEC"
   }

--- a/config/env/prod.json
+++ b/config/env/prod.json
@@ -13,7 +13,7 @@
   "readyRetryIntervalMS": "@@READY_RETRY_INTERVAL_MS",
   "requireAuth": "@@REQUIRE_AUTH",
   "schedulerIntervalMS": "@@SCHEDULER_INTERVAL_MS",
-  "schedulerStopAfterFail": "@@SCHEDULER_STOP_AFTER_FAIL",
+  "schedulerStopAfterNoOp": "@@SCHEDULER_STOP_AFTER_NO_OP",
   "carStorage": {
     "mode": "@@MERKLE_CAR_STORAGE_MODE",
     "s3BucketName": "@@S3_BUCKET_NAME"

--- a/config/env/test.json
+++ b/config/env/test.json
@@ -57,9 +57,7 @@
     "type": "sqs",
     "awsRegion": "us-east-1",
     "sqsQueueUrl": "",
-    "pollingIntervalMS": 10000,
-    "maxAttemptsToRetrieveMessages": 0,
     "maxTimeToHoldMessageSec": 10800,
-    "waitTimeForMessageSec": 30
+    "waitTimeForMessageSec": 10
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -307,11 +307,11 @@ export class CeramicAnchorApp {
     }
 
 
-    const cbAfterEmptyBatch = () => {
+    const cbAfterNoOp = () => {
       logger.imp('No batches available. Continual anchoring is shutting down.')
       process.exit(0)
     }
 
-    continualAnchoringScheduler.start(task, this.config.schedulerIntervalMS, this.config.schedulerStopAfterFail ? cbAfterEmptyBatch : undefined)
+    continualAnchoringScheduler.start(task, this.config.schedulerIntervalMS, this.config.schedulerStopAfterNoOp ? cbAfterNoOp : undefined)
   }
 }

--- a/src/services/__tests__/task-scheduler-service.test.ts
+++ b/src/services/__tests__/task-scheduler-service.test.ts
@@ -88,4 +88,26 @@ describe('scheduler service', () => {
     testScheduler.start(task as any, 1000)
     // test doesn't complete until 'done()' is called
   })
+
+  test('Will stop after failure if stopAfterFailure set', async () => {
+    let completedOnce = false
+    const task = jest.fn()
+    task.mockImplementation(async (): Promise<boolean> => {
+      if (!completedOnce) {
+        completedOnce = true
+        return Promise.resolve(true)
+      }
+      return Promise.resolve(false)
+    })
+    const cbAfterFailure = jest.fn(() => Promise.resolve())
+
+    const testScheduler = new TaskSchedulerService()
+    testScheduler.start(task as any, 1000, cbAfterFailure)
+
+    await Utils.delay(5000)
+
+    await testScheduler.stop()
+    expect(task.mock.calls.length).toEqual(2)
+    expect(cbAfterFailure.mock.calls.length).toEqual(1)
+  })
 })

--- a/src/services/__tests__/task-scheduler-service.test.ts
+++ b/src/services/__tests__/task-scheduler-service.test.ts
@@ -89,7 +89,7 @@ describe('scheduler service', () => {
     // test doesn't complete until 'done()' is called
   })
 
-  test('Will run cbAfterFailure after failure if set', async () => {
+  test('Will run cbAfterNoOp after failure if set', async () => {
     let completedOnce = false
     const task = jest.fn()
     task.mockImplementation(async (): Promise<boolean> => {
@@ -99,15 +99,15 @@ describe('scheduler service', () => {
       }
       return Promise.resolve(false)
     })
-    const cbAfterFailure = jest.fn(() => Promise.resolve())
+    const cbAfterNoOp = jest.fn(() => Promise.resolve())
 
     const testScheduler = new TaskSchedulerService()
-    testScheduler.start(task as any, 1000, cbAfterFailure)
+    testScheduler.start(task as any, 1000, cbAfterNoOp)
 
     await Utils.delay(5000)
 
     await testScheduler.stop()
     expect(task.mock.calls.length).toEqual(2)
-    expect(cbAfterFailure.mock.calls.length).toEqual(1)
+    expect(cbAfterNoOp.mock.calls.length).toEqual(1)
   })
 })

--- a/src/services/__tests__/task-scheduler-service.test.ts
+++ b/src/services/__tests__/task-scheduler-service.test.ts
@@ -89,7 +89,7 @@ describe('scheduler service', () => {
     // test doesn't complete until 'done()' is called
   })
 
-  test('Will stop after failure if stopAfterFailure set', async () => {
+  test('Will run cbAfterFailure after failure if set', async () => {
     let completedOnce = false
     const task = jest.fn()
     task.mockImplementation(async (): Promise<boolean> => {

--- a/src/services/task-scheduler-service.ts
+++ b/src/services/task-scheduler-service.ts
@@ -21,10 +21,10 @@ export class TaskSchedulerService {
    * Starts the scheduler which will run the provided task at regular intervals
    * @param task task to perform regularly with a delay of intervalMS between runs
    * @param intervalMS default: 60000, delay between task runs
-   * @param cbAfterFailure default undefined. cbAfterFailure is the callback to run if the task returns false. A task returning false indicates that it did not run or finish. 
-   * cbAfterFailure will not be called if the task errors. If cbAfterFailure is not set then the scheduler will continue to run the task regardless if the task was successful or not.
+   * @param cbAfterNoOp default undefined. cbAfterNoOp is the callback to run if the task returns false. A task returning false indicates that it did not do anything (no op)
+   * cbAfterNoOp will not be called if the task errors. If cbAfterNoOp is not set then the scheduler will continue to run the task regardless if the task was a no op or not
    */
-  start(task: () => Promise<boolean | void>, intervalMS = 60000, cbAfterFailure?: () => Promise<void>): void {
+  start(task: () => Promise<boolean | void>, intervalMS = 60000, cbAfterNoOp?: () => Promise<void>): void {
     if (this._scheduledTask$) {
       throw new Error('Task already scheduled')
     }
@@ -59,7 +59,7 @@ export class TaskSchedulerService {
           return EMPTY
         }
 
-        if (cbAfterFailure && !success) {
+        if (cbAfterNoOp && !success) {
           logger.imp(`Last run of the task was not successful. Stopping the task scheduler`)
           return EMPTY
         }
@@ -72,7 +72,7 @@ export class TaskSchedulerService {
 
     this._subscription = this._scheduledTask$.subscribe({
       complete: async () => {
-        if (cbAfterFailure) await cbAfterFailure()
+        if (cbAfterNoOp) await cbAfterNoOp()
       }
     })
   }

--- a/src/services/task-scheduler-service.ts
+++ b/src/services/task-scheduler-service.ts
@@ -7,29 +7,36 @@ import { METRIC_NAMES } from '../settings.js'
  * Repeatedly triggers a task to be run after a configured amount of ms
  */
 export class TaskSchedulerService {
-  private _scheduledTask$?: Observable<void>
+  private _scheduledTask$?: Observable<boolean | void>
   private _controller: AbortController
+  private _completed = false
 
-  /**
-   * Starts the scheduler which will run the provided task
-   *
-   */
+
   constructor() {
     this._controller = new AbortController()
   }
 
-  start(task: () => Promise<void>, intervalMS = 60000): void {
+
+  /**
+   * Starts the scheduler which will run the provided task at regular intervals
+   * @param task task to perform regularly with a delay of intervalMS between runs
+   * @param intervalMS default: 60000, delay between task runs
+   * @param cbAfterFailure default undefined. cbAfterFailure is the callback to run if the task returns false. A task returning false indicates that it did not run or finish. 
+   * cbAfterFailure will not be called if the task errors. If cbAfterFailure is not set then the scheduler will continue to run the task regardless if the task was successful or not.
+   */
+  start(task: () => Promise<boolean | void>, intervalMS = 60000, cbAfterFailure?: () => Promise<void>): void {
     if (this._scheduledTask$) {
-      return
+      throw new Error('Task already scheduled')
     }
 
-    const taskWithRetryOnError$ = defer(async () => {
+    const taskWithRetryOnError$ = defer(async (): Promise<boolean> => {
       if (this._controller.signal.aborted) {
-        return
+        return false
       }
-      await task()
+
+      return await task().then(result => result === undefined || result)
     }).pipe(
-      catchError((err) => {
+      catchError((err: Error) => {
         Metrics.count(METRIC_NAMES.SCHEDULER_TASK_UNCAUGHT_ERROR, 1)
         logger.err(`Scheduler task failed: ${err}`)
 
@@ -47,8 +54,13 @@ export class TaskSchedulerService {
     )
 
     this._scheduledTask$ = taskWithRetryOnError$.pipe(
-      expand(() => {
+      expand((success: boolean) => {
         if (this._controller.signal.aborted) {
+          return EMPTY
+        }
+
+        if (cbAfterFailure && !success) {
+          logger.imp(`Last run of the task was not successful. Stopping the task scheduler`)
           return EMPTY
         }
 
@@ -57,11 +69,21 @@ export class TaskSchedulerService {
       share()
     )
 
-    this._scheduledTask$.subscribe()
+
+    this._scheduledTask$.subscribe({
+      complete: async () => {
+        if (!this._completed) {
+          this._completed = true
+          if (cbAfterFailure) await cbAfterFailure()
+        }
+      }
+    })
   }
 
   async stop(): Promise<void> {
     if (!this._scheduledTask$) return Promise.resolve()
+
+    if (this._completed) return Promise.resolve()
 
     return new Promise((resolve) => {
       this._scheduledTask$?.subscribe({


### PR DESCRIPTION
Please use environment vars:

APP_MODE=continual-anchoring
SCHEDULER_STOP_AFTER_FAIL=true

to turn this on
