### PR TITLE
fix: REPLACE all previous

### DIFF
--- a/src/controllers/__tests__/request-controller.test.ts
+++ b/src/controllers/__tests__/request-controller.test.ts
@@ -319,7 +319,7 @@ describe('createRequest', () => {
         },
       })
       const requestRepository = container.resolve('requestRepository')
-      const markPreviousReplacedSpy = jest.spyOn(requestRepository, 'markPreviousReplaced')
+      const markPreviousReplacedSpy = jest.spyOn(requestRepository, 'markReplaced')
       await controller.createRequest(req, mockResponse())
       expect(markPreviousReplacedSpy).toBeCalledTimes(1)
     })
@@ -365,7 +365,7 @@ describe('createRequest', () => {
         .spyOn(validationQueueService, 'sendMessage')
         .mockReturnValue(Promise.resolve())
       const requestRepository = container.resolve('requestRepository')
-      const markPreviousReplacedSpy = jest.spyOn(requestRepository, 'markPreviousReplaced')
+      const markPreviousReplacedSpy = jest.spyOn(requestRepository, 'markReplaced')
       await controllerPublishingToQueue.createRequest(req, mockResponse())
       expect(sendMessageSpy).toBeCalledTimes(1)
       // should not mark requests as replaced, the validation service will handle this

--- a/src/repositories/__tests__/request-repository.test.ts
+++ b/src/repositories/__tests__/request-repository.test.ts
@@ -878,9 +878,8 @@ describe('request repository test', () => {
         return requestRepository.createOrUpdate(request)
       })
       const requests: Array<Request> = await Promise.all(requestsP)
-      const first = requests[0]
-      expectPresent(first)
-      const rowsAffected = await requestRepository.markPreviousReplaced(first)
+      expectPresent(requests[0])
+      const rowsAffected = await requestRepository.markPreviousReplaced(requests[0])
       expect(rowsAffected).toEqual(requests.length - 1) // Mark every request except the last one
     })
   })

--- a/src/repositories/__tests__/request-repository.test.ts
+++ b/src/repositories/__tests__/request-repository.test.ts
@@ -795,8 +795,9 @@ describe('request repository test', () => {
   })
 
   describe('markPreviousReplaced', () => {
+    const ONE_HOUR_AGO = DateTime.fromISO('2023-01-01T00:00Z')
+
     test('mark older PENDING entries REPLACED', async () => {
-      const oneHourAgo = DateTime.fromISO('1900-01-01T00:00Z')
       const streamId = randomStreamID()
 
       // Create three COMPLETED requests. These should not be changed
@@ -805,7 +806,7 @@ describe('request repository test', () => {
           const request = new Request({
             cid: randomCID().toString(),
             streamId: streamId.toString(),
-            timestamp: oneHourAgo.minus({ minute: n }).toJSDate(),
+            timestamp: ONE_HOUR_AGO.minus({ minute: n }).toJSDate(),
             status: RequestStatus.COMPLETED,
             origin: 'same-origin',
           })
@@ -818,7 +819,7 @@ describe('request repository test', () => {
         new Request({
           cid: randomCID().toString(),
           streamId: randomStreamID().toString(),
-          timestamp: oneHourAgo.toJSDate(),
+          timestamp: ONE_HOUR_AGO.toJSDate(),
           status: RequestStatus.PENDING,
           origin: 'same-origin',
         })
@@ -829,7 +830,7 @@ describe('request repository test', () => {
         const request = new Request({
           cid: randomCID().toString(),
           streamId: streamId.toString(),
-          timestamp: oneHourAgo.plus({ minute: n }).toJSDate(),
+          timestamp: ONE_HOUR_AGO.plus({ minute: n }).toJSDate(),
           status: RequestStatus.PENDING,
           origin: 'same-origin',
         })
@@ -862,6 +863,25 @@ describe('request repository test', () => {
       // Our unrelated request should not be affected
       const retrieved = await requestRepository.findByCid(unrelatedStreamRequest.cid)
       expect(retrieved).toEqual(unrelatedStreamRequest)
+    })
+
+    test('mark regardless of time', async () => {
+      const streamId = randomStreamID()
+      const requestsP = times(3).map(async (n) => {
+        const request = new Request({
+          cid: randomCID().toString(),
+          streamId: streamId.toString(),
+          timestamp: ONE_HOUR_AGO.plus({ minute: n }).toJSDate(),
+          status: RequestStatus.PENDING,
+          origin: 'same-origin',
+        })
+        return requestRepository.createOrUpdate(request)
+      })
+      const requests: Array<Request> = await Promise.all(requestsP)
+      const first = requests[0]
+      expectPresent(first)
+      const rowsAffected = await requestRepository.markPreviousReplaced(first)
+      expect(rowsAffected).toEqual(requests.length - 1) // Mark every request except the last one
     })
   })
 

--- a/src/repositories/__tests__/request-repository.test.ts
+++ b/src/repositories/__tests__/request-repository.test.ts
@@ -840,7 +840,7 @@ describe('request repository test', () => {
       const last = requests[requests.length - 1]
       expectPresent(last)
       // First two requests should be marked REPLACED
-      const rowsAffected = await requestRepository.markPreviousReplaced(last)
+      const rowsAffected = await requestRepository.markReplaced(last)
       expect(rowsAffected).toEqual(2)
       const expectedAffected = requests.slice(0, rowsAffected)
       for (const r of expectedAffected) {
@@ -879,7 +879,7 @@ describe('request repository test', () => {
       })
       const requests: Array<Request> = await Promise.all(requestsP)
       expectPresent(requests[0])
-      const rowsAffected = await requestRepository.markPreviousReplaced(requests[0])
+      const rowsAffected = await requestRepository.markReplaced(requests[0])
       expect(rowsAffected).toEqual(requests.length - 1) // Mark every request except the last one
     })
   })

--- a/src/repositories/__tests__/request-repository.test.ts
+++ b/src/repositories/__tests__/request-repository.test.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata'
-import { jest, describe, beforeAll, beforeEach, test, afterAll, expect } from '@jest/globals'
+import { afterAll, beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals'
 import type { Knex } from 'knex'
 import { clearTables, createDbConnection } from '../../db-connection.js'
 import { config } from 'node-config-ts'
@@ -881,6 +881,17 @@ describe('request repository test', () => {
       expectPresent(requests[0])
       const rowsAffected = await requestRepository.markReplaced(requests[0])
       expect(rowsAffected).toEqual(requests.length - 1) // Mark every request except the last one
+      const all = await requestRepository.findByIds(requests.map((r) => r.id))
+      const allById = new Map(
+        all.map((r) => {
+          return [r.id, r]
+        })
+      )
+      expect(allById.get(requests[0].id)?.status).toEqual(RequestStatus.REPLACED)
+      expectPresent(requests[1])
+      expect(allById.get(requests[1].id)?.status).toEqual(RequestStatus.REPLACED)
+      expectPresent(requests[2])
+      expect(allById.get(requests[2].id)?.status).toEqual(RequestStatus.PENDING)
     })
   })
 

--- a/src/repositories/request-repository.ts
+++ b/src/repositories/request-repository.ts
@@ -453,9 +453,9 @@ export class RequestRepository {
   }
 
   /**
-   * Mark PENDING requests older than `request.timestamp` REPLACED if they share same `request.origin` and `request.streamId`s.
+   * Mark all PENDING requests but the last one REPLACED if they share same `request.origin` and `request.streamId`s.
    */
-  markPreviousReplaced(request: Pick<Request, 'origin' | 'streamId' | 'cid'>): Promise<number> {
+  markReplaced(request: Pick<Request, 'origin' | 'streamId' | 'cid'>): Promise<number> {
     return this.table
       .whereIn('id', function () {
         return this.select('id')

--- a/src/repositories/request-repository.ts
+++ b/src/repositories/request-repository.ts
@@ -27,6 +27,8 @@ export const FAILURE_RETRY_INTERVAL = 1000 * 60 * 60 * 6 // 6H
 // application is recommended to automatically retry when seeing this error
 const REPEATED_READ_SERIALIZATION_ERROR = '40001'
 
+const TABLE_NAME = 'request'
+
 /**
  * Records statistics about the set of requests
  * Groups by EXPIRED (if the time is past the deadline), PROCESSING, and FAILED
@@ -89,7 +91,7 @@ export class RequestRepository {
   ) {}
 
   get table() {
-    return this.connection('request')
+    return this.connection(TABLE_NAME)
   }
 
   withConnection(connection: Knex): RequestRepository {
@@ -453,12 +455,27 @@ export class RequestRepository {
   /**
    * Mark PENDING requests older than `request.timestamp` REPLACED if they share same `request.origin` and `request.streamId`s.
    */
-  markPreviousReplaced(request: Request): Promise<number> {
+  markPreviousReplaced(
+    request: Pick<Request, 'origin' | 'streamId' | 'cid' | 'timestamp'>
+  ): Promise<number> {
     return this.table
       .where({ origin: request.origin, streamId: request.streamId })
       .andWhere({ status: RequestStatus.PENDING })
       .andWhere('timestamp', '<', date.encode(request.timestamp))
       .update({ status: RequestStatus.REPLACED, message: `Replaced by ${request.cid}` })
+    // return this.table
+    //   .whereIn('id', function () {
+    //     return this.select('id')
+    //       .from(TABLE_NAME)
+    //       .where({
+    //         origin: request.origin,
+    //         streamId: request.streamId,
+    //         status: RequestStatus.PENDING,
+    //       })
+    //       .orderBy('timestamp', 'DESC')
+    //       .offset(1)
+    //   })
+    //   .update({ status: RequestStatus.REPLACED, message: `Replaced by ${request.cid}` })
   }
 
   /**

--- a/src/repositories/request-repository.ts
+++ b/src/repositories/request-repository.ts
@@ -453,7 +453,7 @@ export class RequestRepository {
   }
 
   /**
-   * Mark all PENDING requests but the last one REPLACED if they share same `request.origin` and `request.streamId`s.
+   * Mark all PENDING requests but the most recent one (by client-side creation timestamp, which may be different than the order that the CAS received them in) REPLACED if they share same `request.origin` and `request.streamId`s.
    */
   markReplaced(request: Pick<Request, 'origin' | 'streamId' | 'cid'>): Promise<number> {
     return this.table

--- a/src/services/__tests__/fake-factory.util.ts
+++ b/src/services/__tests__/fake-factory.util.ts
@@ -41,7 +41,7 @@ export class FakeFactory {
     request.pinned = true
 
     const stored = await this.requestRepository.createOrUpdate(request)
-    await this.requestRepository.markPreviousReplaced(stored)
+    await this.requestRepository.markReplaced(stored)
     return stored
   }
 

--- a/src/services/request-service.ts
+++ b/src/services/request-service.ts
@@ -99,7 +99,7 @@ export class RequestService {
         org: origin,
       })
     } else {
-      await this.requestRepository.markPreviousReplaced(storedRequest)
+      await this.requestRepository.markReplaced(storedRequest)
     }
 
     const did = genesisFields?.controllers?.[0]


### PR DESCRIPTION
Imagine a Ceramic node updates a stream with commit A and tries to request an anchor for commit A from the CAS, but the CAS is temporarily unavailable, say due to the network being down transiently.  The Ceramic node will then start a background task to retry creating the request once every 60 seconds until it goes though.  Then, 30 seconds later, the stream is updated again on the same node, with commit B.  By this point the network has recovered, and the request for commit B is successfully created against the CAS.  Then 30 seconds after that, the anchor request for commit A is retried and goes through.

We have a timestamp inside a request, so commit B still trumps commit A, but we have a bug (or maybe not @stephhuynh18 thanks to CASv5) as we consider REPLACED to be applied to previous requests _relative_ to the current one.