### PR TITLE
feat: enable prometheus endpoint when the port is set

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -56,7 +56,8 @@
   "metrics": {
     "collectorHost": "",
     "exportIntervalMillis": 60000,
-    "exportTimeoutMillis": 30000
+    "exportTimeoutMillis": 30000,
+    "prometheusPort": 0
   },
   "db": {
     "client": "postgresql",

--- a/config/env/dev.json
+++ b/config/env/dev.json
@@ -57,7 +57,8 @@
     "collectorHost": "@@COLLECTOR_HOSTNAME",
     "traceRatio": "@@METRICS_TRACE_RATIO",
     "exportIntervalMillis": "@@METRICS_EXPORT_INTERVAL_MS",
-    "exportTimeoutMillis": "@@METRICS_EXPORT_TIMEOUT_MS"
+    "exportTimeoutMillis": "@@METRICS_EXPORT_TIMEOUT_MS",
+    "prometheusPort": "@@METRICS_PROMETHEUS_PORT"
   },
   "db": {
     "connection": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -121,7 +121,7 @@ export class CeramicAnchorApp {
         DEFAULT_TRACE_SAMPLE_RATIO,
         null,    // no logging inside metrics
         false,   // do not append total to counters automatically
-        0,       // do not turn on the prometheus exporter (use collector only)
+        this.config.metrics.prometheusPort, // turn on the prometheus exporter if port is set
         this.config.metrics.exportIntervalMillis,
         this.config.metrics.exportTimeoutMillis
       )


### PR DESCRIPTION
# Enable prometheus endpoint when the port is set

## Description

When the env var `METRICS_PROMETHEUS_PORT` is set, listen for prometheus metric requests on that port.

Include relevant motivation, context, brief description and impact of the change(s). List follow-up tasks here.

This is an alternative solution to pushing metrics to a opentelemetry collector.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [X] Test A - ran without env var in keramik, no changes
- [X] Test B - ran with env var set, endpoint is available

## Definition of Done

Before submitting this PR, please make sure:

- [X] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [X] My code follows conventions, is well commented, and easy to understand
- [X] My code builds and tests pass without any errors or warnings
- [X] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

