### PR TITLE
Feat/get cacao domain directly

### DIFF
--- a/src/ancillary/__tests__/anchor-request-params-parser.test.ts
+++ b/src/ancillary/__tests__/anchor-request-params-parser.test.ts
@@ -27,8 +27,7 @@ const FAKE_UNSIGNED_TIP = toCID('bafyreigoetnvcimetv4n3dh3pxjeg7x2vym6bjgf7pxjcb
 
 const TIMESTAMP_ISO = '2023-01-25T17:32:42.971Z'
 
-const FAKE_CAPCID='bafyreie2r6tmsvwfatlhpxxqm53npwww36pejsbna36swgvhqm7ukzq3ka'
-
+const FAKE_CACAO='test'  // the p.domain of the cacao in our test blob
 
 const LEGACY_REQUEST_EXAMPLE = mockRequest({
   headers: {
@@ -59,7 +58,7 @@ const CAR_FILE_REQUEST_EXAMPLE_UNSIGNED_GENESIS = mockRequest({
   ),
 })
 
-const CAR_FILE_REQUEST_EXAMPLE_SIGNED_GENESIS_WITH_CAPCID = mockRequest({
+const CAR_FILE_REQUEST_EXAMPLE_SIGNED_GENESIS_WITH_CACAO = mockRequest({
   headers: {
     'Content-Type': 'application/vnd.ipld.car',
   },
@@ -120,12 +119,12 @@ describe('AnchoRequestParamsParser', () => {
     expect((params as RequestAnchorParamsV2).genesisFields).toEqual(CAR_FILE_FAKE_GENESIS_FIELDS)
   })
 
-  test('parses CAR file with signed genesis with capCID properly', () => {
-    const validation = parser.parse(CAR_FILE_REQUEST_EXAMPLE_SIGNED_GENESIS_WITH_CAPCID as ExpReq)
+  test('parses CAR file with signed genesis with cacao properly', () => {
+    const validation = parser.parse(CAR_FILE_REQUEST_EXAMPLE_SIGNED_GENESIS_WITH_CACAO as ExpReq)
     expect(isRight(validation)).toEqual(true)
 
     const params: RequestAnchorParams = (validation as Right<RequestAnchorParams>).right
-    expect(params.capCID).toEqual(FAKE_CAPCID)
+    expect(params.cacaoDomain).toEqual(FAKE_CACAO)
   })
 
   test('isleft indicates invalid car file', () => {

--- a/src/ancillary/anchor-request-params-parser.ts
+++ b/src/ancillary/anchor-request-params-parser.ts
@@ -59,7 +59,7 @@ export const RequestAnchorParamsV2 = sparse({
   timestamp: date,
   cid: cidAsString,
   genesisFields: GenesisFields,
-  capCID: optional(cidAsString)
+  cacaoDomain: optional(String)
 })
 
 export type RequestAnchorParamsV2 = TypeOf<typeof RequestAnchorParamsV2>
@@ -88,16 +88,17 @@ export class AnchorRequestCarFileDecoder implements Decoder<Uint8Array, RequestA
       if (isLeft(rootE)) return context.failures(rootE.left)
       const root = rootE.right
       const genesisCid = root.streamId.cid
-      const [maybeGenesisRecord, capCID] = this.retrieveGenesisRecord(genesisCid, carFile)
+      const maybeGenesisRecord = this.retrieveGenesisRecord(genesisCid, carFile)
       const genesisRecord = decode(IpfsGenesis, maybeGenesisRecord)
       const genesisFields = genesisRecord.header
+      const cacaoDomain = this.extractCacaoDomain(rootRecord, carFile)
 
       return context.success({
         streamId: root.streamId,
         timestamp: root.timestamp,
         cid: root.tip,
         genesisFields: genesisFields,
-        capCID: capCID,
+        cacaoDomain: cacaoDomain,
       })
     } catch (e: any) {
       const message = e.message || String(e)
@@ -105,29 +106,31 @@ export class AnchorRequestCarFileDecoder implements Decoder<Uint8Array, RequestA
     }
   }
 
-  private retrieveGenesisRecord(genesisCid: CID, carFile: CAR): [unknown, CID | undefined] {
+  private extractCacaoDomain(rootRecord: any, carFile: CAR): String {
+    try {
+      const tip = carFile.get(rootRecord.tip)
+      const tipProtectedHeader = base64urlToJSON(carFile.get(rootRecord.tip).signatures[0].protected)
+      return carFile.get(CID.parse(tipProtectedHeader.cap.replace('ipfs://', ''))).p.domain
+    } catch (e: any) {
+      const message = e.message || String(e)
+      logger.warn(`Error extracting cacao: ${message}`)
+      return ''
+    }
+  }
+
+  private retrieveGenesisRecord(genesisCid: CID, carFile: CAR): unknown {
     switch (genesisCid.code) {
       case DAG_CBOR_CODE:
-        return [carFile.get(genesisCid), undefined]
+        return carFile.get(genesisCid)
       case DAG_JOSE_CODE: {
         const genesisJWS = carFile.get(genesisCid)
-        let capCID = undefined
-        const protectedHeader = genesisJWS.signatures[0].protected
-        try { 
-          const capIPFSUri = base64urlToJSON(protectedHeader)['cap']
-          if (capIPFSUri) {
-            capCID = capIPFSUri.replace('ipfs://', '')
-          }
-        } catch (e:any) {
-          const message = e.message || String(e)
-          logger.warn(`Unable to decode protectedHeader: ${message}`)
-        }
-        return [carFile.get(genesisJWS.link), capCID]
+        return carFile.get(genesisJWS.link)
       }
       default:
         throw new Error(`Unsupported codec ${genesisCid.code} for genesis CID ${genesisCid}`)
     }
   }
+
 }
 
 export class AnchorRequestParamsParser {

--- a/src/ancillary/anchor-request-params-parser.ts
+++ b/src/ancillary/anchor-request-params-parser.ts
@@ -1,5 +1,6 @@
 import type { Request as ExpReq } from 'express'
 import type { CID } from 'multiformats/cid'
+import { CID as CIDObj } from 'multiformats/cid'
 import { CARFactory, type CAR } from 'cartonne'
 import { ServiceMetrics as Metrics } from '@ceramicnetwork/observability'
 import { base64urlToJSON } from '@ceramicnetwork/common'
@@ -59,7 +60,7 @@ export const RequestAnchorParamsV2 = sparse({
   timestamp: date,
   cid: cidAsString,
   genesisFields: GenesisFields,
-  cacaoDomain: optional(String)
+  cacaoDomain: optional(string)
 })
 
 export type RequestAnchorParamsV2 = TypeOf<typeof RequestAnchorParamsV2>
@@ -106,11 +107,10 @@ export class AnchorRequestCarFileDecoder implements Decoder<Uint8Array, RequestA
     }
   }
 
-  private extractCacaoDomain(rootRecord: any, carFile: CAR): String {
+  private extractCacaoDomain(rootRecord: any, carFile: CAR): string {
     try {
-      const tip = carFile.get(rootRecord.tip)
       const tipProtectedHeader = base64urlToJSON(carFile.get(rootRecord.tip).signatures[0].protected)
-      return carFile.get(CID.parse(tipProtectedHeader.cap.replace('ipfs://', ''))).p.domain
+      return carFile.get(CIDObj.parse(tipProtectedHeader['cap'].replace('ipfs://', ''))).p.domain
     } catch (e: any) {
       const message = e.message || String(e)
       logger.warn(`Error extracting cacao: ${message}`)

--- a/src/services/request-service.ts
+++ b/src/services/request-service.ts
@@ -112,7 +112,7 @@ export class RequestService {
       model: genesisFields?.model,
       stream: request.streamId,
       origin: request.origin,
-      cap_cid: 'capCID' in params ? params.capCID : '',
+      cacao: 'cacaoDomain' in params ? params.cacaoDomain : '',
     };
 
     Metrics.count(METRIC_NAMES.WRITE_TOTAL_TSDB, 1, logData)


### PR DESCRIPTION
# Pull the CACAO directly from the carfile when present - #PLAT-1576

## Description

So actually, we can log the cacao directly from the carfile without going thru capcid!
just have to pull it out by the rootRecord.tip protected header .cap

## How Has This Been Tested?

Tested locally and modified unit test for it

- [ x] Unit test using a blob generated from js-ceramic

## Definition of Done

Before submitting this PR, please make sure:

- [ x] The work addresses the description and outcomes in the issue
- [x ] I have added relevant tests for new or updated functionality
- [ x] My code follows conventions, is well commented, and easy to understand
- [x ] My code builds and tests pass without any errors or warnings
- [x ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
