### PR TITLE
be compatible with the infra-wide setting for metrics port

### DIFF
--- a/config/env/dev.json
+++ b/config/env/dev.json
@@ -59,7 +59,7 @@
     "traceRatio": "@@METRICS_TRACE_RATIO",
     "exportIntervalMillis": "@@METRICS_EXPORT_INTERVAL_MS",
     "exportTimeoutMillis": "@@METRICS_EXPORT_TIMEOUT_MS",
-    "prometheusPort": "@@METRICS_PROMETHEUS_PORT"
+    "prometheusPort": "@@METRICS_PORT"
   },
   "db": {
     "connection": {

--- a/config/env/prod.json
+++ b/config/env/prod.json
@@ -58,7 +58,8 @@
     "collectorHost": "@@COLLECTOR_HOSTNAME",
     "traceRatio": "@@METRICS_TRACE_RATIO",
     "exportIntervalMillis": "@@METRICS_EXPORT_INTERVAL_MS",
-    "exportTimeoutMillis": "@@METRICS_EXPORT_TIMEOUT_MS"
+    "exportTimeoutMillis": "@@METRICS_EXPORT_TIMEOUT_MS",
+    "prometheusPort": "@@METRICS_PORT"
   },
   "db": {
     "connection": {

--- a/config/env/test.json
+++ b/config/env/test.json
@@ -39,7 +39,8 @@
     "collectorHost": "@@COLLECTOR_HOSTNAME",
     "traceRatio": "@@METRICS_TRACE_RATIO",
     "exportIntervalMillis": "@@METRICS_EXPORT_INTERVAL_MS",
-    "exportTimeoutMillis": "@@METRICS_EXPORT_TIMEOUT_MS"
+    "exportTimeoutMillis": "@@METRICS_EXPORT_TIMEOUT_MS",
+    "prometheusPort": "@@METRICS_PORT"
   },
   "db": {
     "client": "postgresql",


### PR DESCRIPTION
# Enable Prometheus Scraping of Metrics - #INFRA-14

## Description

The historical environment variable is METRICS_PORT, across different node types.  Better to be consistent.

This will allow us to turn on prometheus endpoint to be scraped on cas.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x ] Unit tests

## Definition of Done

Before submitting this PR, please make sure:

- [ x] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [x ] My code builds and tests pass without any errors or warnings
- [x ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ x] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
