### PR TITLE
Set a knex pool size to 3 - 30

### DIFF
--- a/src/db-connection.ts
+++ b/src/db-connection.ts
@@ -45,7 +45,7 @@ export async function createDbConnection(dbConfig: Db = config.db): Promise<Knex
     connection: dbConfig.connection.connectionString || dbConfig.connection,
     debug: dbConfig.debug,
     migrations: dbConfig.migrations,
-
+    pool: { min: 3, max: 30 },
     // In our DB, identifiers have snake case formatting while in our code identifiers have camel case formatting.
     // We use the following transformers so we can always use camel case formatting in our code.
 


### PR DESCRIPTION
Configure a connection for knex for 3-30. It appears to be using the default, which is 2-10.

