### PR TITLE
feat: add pubsub responder window

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -14,6 +14,7 @@
   "requireAuth": false,
   "schedulerIntervalMS": 300000,
   "schedulerStopAfterNoOp": false,
+  "pubsubResponderWindowMs": 8035200000,
   "carStorage": {
     "mode": "inmemory",
     "s3BucketName": "myS3Bucket",

--- a/config/env/dev.json
+++ b/config/env/dev.json
@@ -14,6 +14,7 @@
   "requireAuth": "@@REQUIRE_AUTH",
   "schedulerIntervalMS": "@@SCHEDULER_INTERVAL_MS",
   "schedulerStopAfterNoOp": "@@SCHEDULER_STOP_AFTER_NO_OP",
+  "pubsubResponderWindowMs": "@@PUBSUB_RESPONDER_WINDOW_MS",
   "carStorage": {
     "mode": "@@MERKLE_CAR_STORAGE_MODE",
     "s3BucketName": "@@S3_BUCKET_NAME",

--- a/config/env/prod.json
+++ b/config/env/prod.json
@@ -14,6 +14,7 @@
   "requireAuth": "@@REQUIRE_AUTH",
   "schedulerIntervalMS": "@@SCHEDULER_INTERVAL_MS",
   "schedulerStopAfterNoOp": "@@SCHEDULER_STOP_AFTER_NO_OP",
+  "pubsubResponderWindowMs": "@@PUBSUB_RESPONDER_WINDOW_MS",
   "carStorage": {
     "mode": "@@MERKLE_CAR_STORAGE_MODE",
     "s3BucketName": "@@S3_BUCKET_NAME",

--- a/src/repositories/__tests__/request-repository.test.ts
+++ b/src/repositories/__tests__/request-repository.test.ts
@@ -1038,6 +1038,28 @@ describe('request repository test', () => {
       const received = await requestRepository.findCompletedForStream(myStreamId)
       expect(expectedRequest.map(({ id }) => id)).toEqual(received.map(({ id }) => id))
     })
+
+    test('If the completed request for a given stream is too old, return an empty array', async () => {
+      const myStreamId = randomStreamID().toString()
+      const after = new Date(Date.now() - 1000 * 60 * 60)
+      const requests = generateRequests(
+        {
+          streamId: myStreamId,
+          status: RequestStatus.COMPLETED,
+          updatedAt: new Date(after.getTime() - 1),
+        },
+        1
+      )
+
+      await requestRepository.createRequests(requests)
+
+      const createdRequests = await requestRepository.allRequests()
+      expect(requests.length).toEqual(createdRequests.length)
+
+      const received = await requestRepository.findCompletedForStream(myStreamId, 1, after)
+      expect(received.length).toEqual(0)
+    })
+
     test('If there is no completed request for a given stream, return an empty array', async () => {
       const myStreamId = randomStreamID().toString()
       const requests = [

--- a/src/repositories/request-repository.ts
+++ b/src/repositories/request-repository.ts
@@ -609,12 +609,22 @@ export class RequestRepository {
     return returned.map((r) => new Request(r))
   }
 
-  async findCompletedForStream(streamId: string | StreamID, limit = 1): Promise<Array<Request>> {
-    const found = await this.table
+  async findCompletedForStream(
+    streamId: string | StreamID,
+    limit = 1,
+    after?: Date
+  ): Promise<Array<Request>> {
+    const query = this.table
       .where({ streamId: streamId.toString() })
-      .where({ status: RequestStatus.COMPLETED })
+      .andWhere({ status: RequestStatus.COMPLETED })
       .orderBy('updatedAt', 'desc')
       .limit(limit)
+
+    if (after) {
+      query.andWhere('updatedAt', '>=', date.encode(after))
+    }
+
+    const found = await query
 
     return found.map((r) => new Request(r))
   }


### PR DESCRIPTION
We have gotten into a scenario where we were receiving anchor status requests for really old streams/cid combos. In light of this as a safeguard lets only respond to anchors happening in the last three months. Though this is configurable so can be easily changed. 