### PR TITLE
feat: exit with error when an anchor worker fails to anchor a batch

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -302,10 +302,12 @@ export class CeramicAnchorApp {
       const success = await anchorService
         .anchorRequests({ signal: controller.signal })
         .catch((error: Error) => {
-          logger.err(`Error when anchoring: ${error}`)
-          Metrics.count(METRIC_NAMES.ERROR_WHEN_ANCHORING, 1, {
-            message: error.message.substring(0, 50),
-          })
+          if (!controller.signal.aborted) {
+            logger.err(`Error when anchoring: ${error}`)
+            Metrics.count(METRIC_NAMES.ERROR_WHEN_ANCHORING, 1, {
+              message: error.message.substring(0, 50),
+            })
+          }
           throw error
         })
 

--- a/src/services/__tests__/task-scheduler-service.test.ts
+++ b/src/services/__tests__/task-scheduler-service.test.ts
@@ -2,38 +2,32 @@ import 'reflect-metadata'
 import { jest, describe, test, expect } from '@jest/globals'
 import { TaskSchedulerService } from '../task-scheduler-service.js'
 import { Utils } from '../../utils.js'
+import { TestUtils } from '@ceramicnetwork/common'
 
 describe('scheduler service', () => {
   jest.setTimeout(20000)
 
-  test('will run the task repeatedly', (done) => {
+  test('will run the task repeatedly', async () => {
     const numberOfRunsBeforeDone = 3
 
     const task = jest.fn()
     const testScheduler = new TaskSchedulerService()
 
-    const runChecks = () => {
-      // the task runs once right at the start before running every X seconds
-      expect(task.mock.calls.length).toEqual(numberOfRunsBeforeDone + 1)
-      done()
-    }
-
     let count = 0
     task.mockImplementation(async () => {
-      if (count === numberOfRunsBeforeDone) {
-        testScheduler.stop()
-        runChecks()
-      }
-
       count = count + 1
       return Promise.resolve()
     })
 
     testScheduler.start(task as any, 1000)
-    // test doesn't complete until 'done()' is called
+    await TestUtils.delay(1000 * numberOfRunsBeforeDone)
+    await testScheduler.stop()
+    expect(task.mock.calls.length).toBeGreaterThanOrEqual(numberOfRunsBeforeDone)
   })
 
-  test('will stop if the task fails', (done) => {
+  test('will stop if the task fails', async () => {
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {})
+
     const task = jest.fn()
     const testScheduler = new TaskSchedulerService()
 
@@ -42,42 +36,37 @@ describe('scheduler service', () => {
       count = count + 1
 
       if (count === 2) {
-        return Promise.reject('test error')
+        throw Error('test error')
       }
 
-      return Promise.resolve()
+      return
     })
 
     testScheduler.start(task as any, 1000)
-    // @ts-ignore
-    testScheduler._subscription?.add(() => {
-      expect(task.mock.calls.length).toEqual(2)
-      testScheduler.stop()
-      done()
+    await TestUtils.waitForConditionOrTimeout(async () => {
+      // @ts-ignore
+      return testScheduler._subscription?.closed || false
     })
-    // test doesn't complete until 'done()' is called
+    expect(mockExit).toHaveBeenCalled()
   })
 
-  test('Will complete current task if stop is called', (done) => {
+  test('Will complete current task if stop is called', async () => {
     let calls = 0
     const task = async () => {
       await Utils.delay(2000)
       calls = calls + 1
     }
+
     const testScheduler = new TaskSchedulerService()
 
+    testScheduler.start(task as any, 1000)
+    await Utils.delay(500)
     // stop is called during the task
     // stop should only return once the task completes
-    Utils.delay(1000).then(async () => {
-      await testScheduler.stop()
-      await Utils.delay(3000)
-      // task should have compelted once
-      expect(calls).toEqual(1)
-      done()
-    })
-
-    testScheduler.start(task as any, 1000)
-    // test doesn't complete until 'done()' is called
+    await testScheduler.stop()
+    await Utils.delay(3000)
+    // task should have completed once
+    expect(calls).toEqual(1)
   })
 
   test('Will run cbAfterNoOp after failure if set', async () => {

--- a/src/services/__tests__/task-scheduler-service.test.ts
+++ b/src/services/__tests__/task-scheduler-service.test.ts
@@ -2,7 +2,6 @@ import 'reflect-metadata'
 import { jest, describe, test, expect } from '@jest/globals'
 import { TaskSchedulerService } from '../task-scheduler-service.js'
 import { Utils } from '../../utils.js'
-import { TestUtils } from '@ceramicnetwork/common'
 
 describe('scheduler service', () => {
   jest.setTimeout(20000)

--- a/src/services/__tests__/task-scheduler-service.test.ts
+++ b/src/services/__tests__/task-scheduler-service.test.ts
@@ -26,7 +26,9 @@ describe('scheduler service', () => {
   })
 
   test('will stop if the task fails', async () => {
-    const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {})
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {
+      return
+    })
 
     const task = jest.fn()
     const testScheduler = new TaskSchedulerService()

--- a/src/services/task-scheduler-service.ts
+++ b/src/services/task-scheduler-service.ts
@@ -1,5 +1,15 @@
 import { logger } from '../logger/index.js'
-import { catchError, Observable, Subscription, defer, share, timer, expand, concatMap, EMPTY, retry } from 'rxjs'
+import {
+  catchError,
+  Observable,
+  Subscription,
+  defer,
+  share,
+  timer,
+  expand,
+  concatMap,
+  EMPTY,
+} from 'rxjs'
 import { ServiceMetrics as Metrics } from '@ceramicnetwork/observability'
 import { METRIC_NAMES } from '../settings.js'
 
@@ -11,11 +21,9 @@ export class TaskSchedulerService {
   private _controller: AbortController
   private _subscription?: Subscription
 
-
   constructor() {
     this._controller = new AbortController()
   }
-
 
   /**
    * Starts the scheduler which will run the provided task at regular intervals
@@ -24,7 +32,11 @@ export class TaskSchedulerService {
    * @param cbAfterNoOp default undefined. cbAfterNoOp is the callback to run if the task returns false. A task returning false indicates that it did not do anything (no op)
    * cbAfterNoOp will not be called if the task errors. If cbAfterNoOp is not set then the scheduler will continue to run the task regardless if the task was a no op or not
    */
-  start(task: () => Promise<boolean | void>, intervalMS = 60000, cbAfterNoOp?: () => Promise<void>): void {
+  start(
+    task: () => Promise<boolean | void>,
+    intervalMS = 60000,
+    cbAfterNoOp?: () => Promise<void>
+  ): void {
     if (this._scheduledTask$) {
       throw new Error('Task already scheduled')
     }
@@ -34,7 +46,7 @@ export class TaskSchedulerService {
         return false
       }
 
-      return await task().then(result => result === undefined || result)
+      return await task().then((result) => result === undefined || result)
     }).pipe(
       catchError((err: Error) => {
         Metrics.count(METRIC_NAMES.SCHEDULER_TASK_UNCAUGHT_ERROR, 1)
@@ -45,11 +57,6 @@ export class TaskSchedulerService {
         }
 
         throw err
-      }),
-      retry({
-        delay: intervalMS,
-        count: 3,
-        resetOnSuccess: true,
       })
     )
 
@@ -63,17 +70,15 @@ export class TaskSchedulerService {
           logger.imp(`Last run of the task was not successful. Stopping the task scheduler`)
           return EMPTY
         }
-
         return timer(intervalMS).pipe(concatMap(() => taskWithRetryOnError$))
       }),
       share()
     )
 
-
     this._subscription = this._scheduledTask$.subscribe({
       complete: async () => {
         if (cbAfterNoOp) await cbAfterNoOp()
-      }
+      },
     })
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -60,10 +60,6 @@ export enum METRIC_NAMES {
   WITNESS_CAR_CACHE_MISS = 'witness_car_cache_miss',
 
   // *******************************************************************//
-  // Scheduler Service
-  SCHEDULER_TASK_UNCAUGHT_ERROR = 'scheduler_task_uncaught_error',
-
-  // *******************************************************************//
   // Ceramic Service
   PIN_SUCCEEDED = 'pin_succeeded',
   PIN_FAILED = 'pin_failed',
@@ -80,4 +76,3 @@ export enum METRIC_NAMES {
   REQUEST_NOT_CREATED = 'request_not_created',
   REQUEST_NOT_FOUND = 'request_not_found',
 }
-


### PR DESCRIPTION
Before: retry 3 times before erroring out
After: no retries, better for debugging

Tested:
tested manually
altered unit test