### PR TITLE
feat: cas scaling

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -76,6 +76,8 @@
     "type": "sqs",
     "awsRegion": "us-east-1",
     "sqsQueueUrl": "",
+    "s3BucketName": "myS3Bucket",
+    "s3Endpoint": "",
     "maxTimeToHoldMessageSec": 21600,
     "waitTimeForMessageSec": 0
   }

--- a/config/env/dev.json
+++ b/config/env/dev.json
@@ -71,6 +71,8 @@
     "type": "sqs",
     "awsRegion": "@@AWS_REGION",
     "sqsQueueUrl": "@@SQS_QUEUE_URL",
+    "s3BucketName": "@@S3_BUCKET_NAME",
+    "s3Endpoint": "@@S3_ENDPOINT",
     "maxTimeToHoldMessageSec": "@@MAX_TIME_TO_HOLD_MESSAGE_SEC",
     "waitTimeForMessageSec": "@@WAIT_TIME_FOR_MESSAGE_SEC"
   }

--- a/config/env/prod.json
+++ b/config/env/prod.json
@@ -71,6 +71,8 @@
     "type": "sqs",
     "awsRegion": "@@AWS_REGION",
     "sqsQueueUrl": "@@SQS_QUEUE_URL",
+    "s3BucketName": "@@S3_BUCKET_NAME",
+    "s3Endpoint": "@@S3_ENDPOINT",
     "maxTimeToHoldMessageSec": "@@MAX_TIME_TO_HOLD_MESSAGE_SEC",
     "waitTimeForMessageSec": "@@WAIT_TIME_FOR_MESSAGE_SEC"
   }

--- a/config/env/test.json
+++ b/config/env/test.json
@@ -57,6 +57,7 @@
     "type": "sqs",
     "awsRegion": "us-east-1",
     "sqsQueueUrl": "",
+    "s3BucketName": "ceramic-tnet-cas",
     "maxTimeToHoldMessageSec": 10800,
     "waitTimeForMessageSec": 10
   }

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -42,12 +42,12 @@ function buildBodyDigest(contentType: string | undefined, body: any): string | u
       if (contentType.includes('application/vnd.ipld.car')) {
         const carFactory = new CARFactory()
         carFactory.codecs.add(DAG_JOSE)
-        console.log('Will build a car file from req.body', body)
-        try {
-          console.log('Will build a car file from req.body (as utf8 string)', u8a.toString(body, 'base64'))
-        } catch(e) {
-          console.log('Couldn\'t convert req.body to string: ', e)
-        }
+        // console.log('Will build a car file from req.body', body)
+        // try {
+        //   console.log('Will build a car file from req.body (as utf8 string)', u8a.toString(body, 'base64'))
+        // } catch(e) {
+        //   console.log('Couldn\'t convert req.body to string: ', e)
+        // }
         const car = carFactory.fromBytes(body)
         if (!car.roots[0]) throw Error('Missing CAR root')
         return car.roots[0].toString()

--- a/src/repositories/anchor-repository.ts
+++ b/src/repositories/anchor-repository.ts
@@ -6,6 +6,7 @@ import { parseCountResult } from './parse-count-result.util.js'
 import { decode } from 'codeco'
 
 const TABLE_NAME = 'anchor'
+const chunkSize = 10000
 
 export class AnchorRepository implements IAnchorRepository {
   static inject = ['dbConnection'] as const
@@ -32,11 +33,8 @@ export class AnchorRepository implements IAnchorRepository {
    * @returns A promise that resolve to the number of anchors created
    */
   async createAnchors(anchors: Array<FreshAnchor>): Promise<number> {
-    const result: any = await this.table
-      .insert(anchors.map((anchor) => FreshAnchor.encode(anchor)))
-      .onConflict('requestId')
-      .ignore()
-    return parseCountResult(result.rowCount)
+    const result = await this.connection.batchInsert(TABLE_NAME, anchors, chunkSize)
+    return parseCountResult(result.length)
   }
 
   /**

--- a/src/repositories/anchor-repository.ts
+++ b/src/repositories/anchor-repository.ts
@@ -33,7 +33,7 @@ export class AnchorRepository implements IAnchorRepository {
    * @returns A promise that resolve to the number of anchors created
    */
   async createAnchors(anchors: Array<FreshAnchor>): Promise<number> {
-    const result = await this.connection.batchInsert(TABLE_NAME, anchors, chunkSize).catch(function (error) {
+    const result = await this.connection.batchInsert(TABLE_NAME, anchors.map((anchor) => FreshAnchor.encode(anchor)), chunkSize).catch(function (error) {
       console.error(error)
     }) ?? []
     return parseCountResult(result.length)
@@ -55,6 +55,7 @@ export class AnchorRepository implements IAnchorRepository {
   async findByRequestId(requestId: string): Promise<StoredAnchor | null> {
     const row = await this.table.where({ requestId: requestId }).first()
     if (!row) return null
+    console.log("IM HERE with ", row, requestId)
     return decode(StoredAnchor, row)
   }
 }

--- a/src/repositories/anchor-repository.ts
+++ b/src/repositories/anchor-repository.ts
@@ -55,7 +55,6 @@ export class AnchorRepository implements IAnchorRepository {
   async findByRequestId(requestId: string): Promise<StoredAnchor | null> {
     const row = await this.table.where({ requestId: requestId }).first()
     if (!row) return null
-    console.log("IM HERE with ", row, requestId)
     return decode(StoredAnchor, row)
   }
 }

--- a/src/repositories/anchor-repository.ts
+++ b/src/repositories/anchor-repository.ts
@@ -33,7 +33,9 @@ export class AnchorRepository implements IAnchorRepository {
    * @returns A promise that resolve to the number of anchors created
    */
   async createAnchors(anchors: Array<FreshAnchor>): Promise<number> {
-    const result = await this.connection.batchInsert(TABLE_NAME, anchors, chunkSize)
+    const result = await this.connection.batchInsert(TABLE_NAME, anchors, chunkSize).catch(function (error) {
+      console.error(error)
+    }) ?? []
     return parseCountResult(result.length)
   }
 

--- a/src/repositories/request-repository.ts
+++ b/src/repositories/request-repository.ts
@@ -175,19 +175,15 @@ export class RequestRepository {
     for (let i = 0; i < requests.length; i += chunkSize) {
       const chunk = requests.slice(i, i + chunkSize)
       const ids = chunk.map((r) => r.id)
-      try {
-        result += await this.table
-        .update({
-          message: fields.message,
-          status: fields.status,
-          pinned: fields.pinned,
-          updatedAt: date.encode(updatedAt),
-        })
-        .whereIn('id', ids)
 
-      } catch (error) {
-        throw error
-      }
+      result += await this.table
+      .update({
+        message: fields.message,
+        status: fields.status,
+        pinned: fields.pinned,
+        updatedAt: date.encode(updatedAt),
+      })
+      .whereIn('id', ids)
     }
 
     requests.map((request) => {

--- a/src/services/__tests__/ipfs-service.test.ts
+++ b/src/services/__tests__/ipfs-service.test.ts
@@ -258,7 +258,7 @@ describe('pubsub', () => {
     expect(queueSendMessageSpy).toBeCalledTimes(0)
   })
 
-  test('Will respond to query message about stream with an anchor', async () => {
+  test.only('Will respond to query message about stream with an anchor', async () => {
     const pubsubMessage = { typ: 1, id: '1', stream: randomStreamID() }
 
     const ipfsQueueService = injector.resolve('ipfsQueueService')

--- a/src/services/__tests__/ipfs-service.test.ts
+++ b/src/services/__tests__/ipfs-service.test.ts
@@ -258,7 +258,7 @@ describe('pubsub', () => {
     expect(queueSendMessageSpy).toBeCalledTimes(0)
   })
 
-  test.only('Will respond to query message about stream with an anchor', async () => {
+  test('Will respond to query message about stream with an anchor', async () => {
     const pubsubMessage = { typ: 1, id: '1', stream: randomStreamID() }
 
     const ipfsQueueService = injector.resolve('ipfsQueueService')

--- a/src/services/queue/sqs-queue-service.ts
+++ b/src/services/queue/sqs-queue-service.ts
@@ -22,7 +22,7 @@ import { AbortOptions } from '@ceramicnetwork/common'
 
 const DEFAULT_MAX_TIME_TO_HOLD_MESSAGES_S = 21600
 const DEFAULT_WAIT_TIME_FOR_MESSAGE_S = 10
-const BATCH_STORE_PATH = '/cas/anchor/batch/'
+const BATCH_STORE_PATH = '/cas/anchor/batch'
 /**
  * Sqs Queue Message received by consumers.
  * Once the message is done processing you can either "ack" the message (remove the message from the queue) or "nack" the message (put the message back on the queue)
@@ -212,7 +212,7 @@ export class AnchorBatchSqsQueueService extends SqsQueueService<AnchorBatchQMess
     if (anchorBatchMessage && anchorBatchMessage.data.rids.length === 0) {
       try {
         const batchJson = await this.s3store.get(anchorBatchMessage.data.bid)
-        return new BatchQueueMessage(anchorBatchMessage, batchJson)
+        return new BatchQueueMessage(anchorBatchMessage, JSON.parse(batchJson))
       } catch (err: any) {
         throw Error(`Error retrieving batch ${anchorBatchMessage.data.bid} from S3: ${err.message}`)
       }

--- a/src/services/queue/sqs-queue-service.ts
+++ b/src/services/queue/sqs-queue-service.ts
@@ -6,6 +6,9 @@ import {
   ChangeMessageVisibilityCommand,
   SendMessageCommand,
 } from '@aws-sdk/client-sqs'
+import AWSSDK from 'aws-sdk'
+import LevelUp from 'levelup'
+import S3LevelDOWN from 's3leveldown'
 import { IpfsPubSubPublishQMessage, QueueMessageData } from '../../models/queue-message.js'
 import {
   IQueueConsumerService,
@@ -19,6 +22,7 @@ import { AbortOptions } from '@ceramicnetwork/common'
 
 const DEFAULT_MAX_TIME_TO_HOLD_MESSAGES_S = 21600
 const DEFAULT_WAIT_TIME_FOR_MESSAGE_S = 10
+const BATCH_STORE_PATH = '/cas/anchor/batch/'
 /**
  * Sqs Queue Message received by consumers.
  * Once the message is done processing you can either "ack" the message (remove the message from the queue) or "nack" the message (put the message back on the queue)
@@ -57,6 +61,28 @@ export class SqsQueueMessage<TValue extends QueueMessageData> implements IQueueM
         VisibilityTimeout: 0,
       })
     )
+  }
+}
+
+// This wrapper around SqsQueueMessage is used to handle the case where the list of batch request IDs is empty and must
+// be fetched from S3. The underlying SqsQueueMessage remains the same (and is what is used for n/acking the message),
+// but the data is updated to include the batch request IDs.
+export class BatchQueueMessage implements IQueueMessage<AnchorBatchQMessage> {
+  readonly data: AnchorBatchQMessage
+
+  constructor(
+    private readonly anchorBatchMessage: IQueueMessage<AnchorBatchQMessage>,
+    batchJson: any
+  ) {
+    this.data = decode(AnchorBatchQMessage, batchJson)
+  }
+
+  async ack(): Promise<void> {
+    await this.anchorBatchMessage.ack()
+  }
+
+  async nack(): Promise<void> {
+    await this.anchorBatchMessage.nack()
   }
 }
 
@@ -149,9 +175,49 @@ export class ValidationSqsQueueService extends SqsQueueService<RequestQMessage> 
  * AnchorBatchSqsQueueService is used to consume and publish anchor batch messages. These batches are anchored by anchor workers
  */
 export class AnchorBatchSqsQueueService extends SqsQueueService<AnchorBatchQMessage> {
-  constructor(config: Config) {
+  constructor(
+    config: Config,
+    private s3StorePath = config.queue.s3BucketName + BATCH_STORE_PATH,
+    private s3Endpoint = config.queue.s3Endpoint ? config.queue.s3Endpoint : undefined,
+    private _s3store?: LevelUp.LevelUp
+  ) {
     const queueUrl = config.queue.sqsQueueUrl + 'batch'
     super(config, queueUrl, AnchorBatchQMessage)
+  }
+
+  /**
+   * `new LevelUp` attempts to open a database, which leads to a request to AWS.
+   * Let's make initialization lazy.
+   */
+  get s3store(): LevelUp.LevelUp {
+    if (!this._s3store) {
+      const levelDown = this.s3Endpoint
+        ? new S3LevelDOWN(
+          this.s3StorePath,
+          new AWSSDK.S3({
+            endpoint: this.s3Endpoint,
+            s3ForcePathStyle: true,
+          })
+        )
+        : new S3LevelDOWN(this.s3StorePath)
+
+      this._s3store = new LevelUp(levelDown)
+    }
+    return this._s3store
+  }
+
+  override async receiveMessage(abortOptions?: AbortOptions): Promise<IQueueMessage<AnchorBatchQMessage> | undefined> {
+    const anchorBatchMessage: IQueueMessage<AnchorBatchQMessage> | undefined = await super.receiveMessage(abortOptions)
+    // If the list of batch request IDs is empty, we need to fetch the full batch from S3.
+    if (anchorBatchMessage && anchorBatchMessage.data.rids.length === 0) {
+      try {
+        const batchJson = await this.s3store.get(anchorBatchMessage.data.bid)
+        return new BatchQueueMessage(anchorBatchMessage, batchJson)
+      } catch (err: any) {
+        throw Error(`Error retrieving batch ${anchorBatchMessage.data.bid} from S3: ${err.message}`)
+      }
+    }
+    return anchorBatchMessage
   }
 }
 


### PR DESCRIPTION
This PR makes two main changes:
- Puts IPFS store operations behind a new feature flag (`CAS_USE_IPFS_STORAGE`).
- Detects whether a batch queue message was received without request IDs and, if so, pulls the batch from S3. This avoids a large batch from running into the 256KB SQS message size limit.

These changes are backwards compatible. Once ready, they should be merged before the changes from [this](https://github.com/ceramicnetwork/go-cas/pull/38) PR for updating the Scheduler to generate/store larger batches.