### PR TITLE
fix: only create request if it does not exist

### DIFF
--- a/src/repositories/request-repository.ts
+++ b/src/repositories/request-repository.ts
@@ -110,16 +110,19 @@ export class RequestRepository {
   }
 
   /**
-   * Create/update client request
-   * @returns A promise that resolves to the created request
+   * Create a client request
+   * @returns A promise that resolves to the created request if it doesn't already exist
    */
-  async createOrUpdate(request: Request): Promise<Request> {
-    const keys = Object.keys(request).filter((key) => key !== 'id') // all keys except ID
+  async create(request: Request): Promise<Request | null> {
     const [created] = await this.table
       .insert(request.toDB(), ['id'])
       .returning(Object.keys(RequestCodec.props))
       .onConflict('cid')
-      .merge(keys)
+      .ignore()
+
+    if (!created) {
+      return null
+    }
 
     logEvent.db({
       type: 'request',
@@ -139,10 +142,13 @@ export class RequestRepository {
   /**
    * For test use. Creates an array of requests.
    * @param requests array of requests
-   * @returns
+   * @returns array of the stored requests
    */
-  async createRequests(requests: Array<Request>): Promise<void> {
-    await this.table.insert(requests.map((request) => request.toDB()))
+  async createRequests(requests: Array<Request>): Promise<Request[]> {
+    const stored = await this.table
+      .insert(requests.map((request) => request.toDB()))
+      .returning(Object.keys(RequestCodec.props))
+    return stored.map((r) => new Request(r))
   }
 
   /**

--- a/src/services/__tests__/fake-factory.util.ts
+++ b/src/services/__tests__/fake-factory.util.ts
@@ -40,7 +40,10 @@ export class FakeFactory {
     request.message = 'Request is pending.'
     request.pinned = true
 
-    const stored = await this.requestRepository.createOrUpdate(request)
+    const stored = await this.requestRepository.create(request)
+    if (!stored) {
+      throw new Error(`Request with cid ${request.cid} already exists. Cannot create again`)
+    }
     await this.requestRepository.markReplaced(stored)
     return stored
   }

--- a/src/services/__tests__/ipfs-service.test.ts
+++ b/src/services/__tests__/ipfs-service.test.ts
@@ -273,12 +273,15 @@ describe('pubsub', () => {
       }
     )
     const requestRepository = injector.resolve('requestRepository')
-    const createdRequest = await requestRepository.createOrUpdate(
+    const createdRequest = await requestRepository.create(
       generateRequest({
         streamId: pubsubMessage.stream.toString(),
         status: RequestStatus.COMPLETED,
       })
     )
+    if (!createdRequest) {
+      throw new Error('Failed to create request because it already exists')
+    }
     const anchorRepository = injector.resolve('anchorRepository')
     const anchorCid = randomCID()
     await anchorRepository.createAnchors([
@@ -324,7 +327,7 @@ describe('pubsub', () => {
     // @ts-ignore
     const beforeWindow = new Date(Date.now() - service.pubsubResponderWindowMs - 1000)
     const requestRepository = injector.resolve('requestRepository')
-    const createdRequest = await requestRepository.createOrUpdate(
+    const createdRequest = await requestRepository.create(
       generateRequest({
         streamId: pubsubMessage.stream.toString(),
         status: RequestStatus.COMPLETED,
@@ -333,6 +336,9 @@ describe('pubsub', () => {
         updatedAt: beforeWindow,
       })
     )
+    if (!createdRequest) {
+      throw new Error('Failed to create request because it already exists')
+    }
     const anchorRepository = injector.resolve('anchorRepository')
     const anchorCid = randomCID()
     await anchorRepository.createAnchors([


### PR DESCRIPTION
problem: we used to merge on conflict when creating requests. This can result in multiple messages set to the scheduler, and misleading log messages

fix: ignore on conflict 

added unit tests