### PR TITLE
Clarify Metric Names - #WS2-3181

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14322,7 +14322,6 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -14680,7 +14679,6 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"

--- a/src/ancillary/anchor-request-params-parser.ts
+++ b/src/ancillary/anchor-request-params-parser.ts
@@ -139,13 +139,13 @@ export class AnchorRequestParamsParser {
   parse(req: ExpReq): Validation<RequestAnchorParams> {
     if (req.get('Content-Type') !== 'application/vnd.ipld.car') {
       // Legacy requests
-      Metrics.count(METRIC_NAMES.LEGACY_REQUESTED, 1)
+      Metrics.count(METRIC_NAMES.C_LEGACY_REQUESTED, 1)
       return validate(RequestAnchorParamsV1, req.body)
     } else {
       // Next version of anchor requests, using the CAR file format
       // TODO: CDB-2212 Store the car file somewhere for future reference/validation of signatures
       // (as it also includes the tip commit and optionally CACAO for the tip commit)
-      Metrics.count(METRIC_NAMES.CAR_REQUESTED, 1)
+      Metrics.count(METRIC_NAMES.C_CAR_REQUESTED, 1)
       return validate(this.v2decoder, req.body)
     }
   }

--- a/src/ancillary/anchor-request-params-parser.ts
+++ b/src/ancillary/anchor-request-params-parser.ts
@@ -139,13 +139,13 @@ export class AnchorRequestParamsParser {
   parse(req: ExpReq): Validation<RequestAnchorParams> {
     if (req.get('Content-Type') !== 'application/vnd.ipld.car') {
       // Legacy requests
-      Metrics.count(METRIC_NAMES.C_LEGACY_REQUESTED, 1)
+      Metrics.count(METRIC_NAMES.CTRL_LEGACY_REQUESTED, 1)
       return validate(RequestAnchorParamsV1, req.body)
     } else {
       // Next version of anchor requests, using the CAR file format
       // TODO: CDB-2212 Store the car file somewhere for future reference/validation of signatures
       // (as it also includes the tip commit and optionally CACAO for the tip commit)
-      Metrics.count(METRIC_NAMES.C_CAR_REQUESTED, 1)
+      Metrics.count(METRIC_NAMES.CTRL_CAR_REQUESTED, 1)
       return validate(this.v2decoder, req.body)
     }
   }

--- a/src/controllers/request-controller.ts
+++ b/src/controllers/request-controller.ts
@@ -135,6 +135,7 @@ export class RequestController {
         )
       }
       logger.debug(`Found request for ${requestParams.cid} of stream ${requestParams.streamId}`)
+      Metrics.count(METRIC_NAMES.ANCHOR_ACCEPTED, 1, { source: parseOrigin(req) })
       return res.status(StatusCodes.ACCEPTED).json(found)
     } catch (err: any) {
       Metrics.count(METRIC_NAMES.REQUEST_NOT_CREATED, 1, { source: parseOrigin(req) })

--- a/src/controllers/request-controller.ts
+++ b/src/controllers/request-controller.ts
@@ -135,7 +135,7 @@ export class RequestController {
         )
       }
       logger.debug(`Found request for ${requestParams.cid} of stream ${requestParams.streamId}`)
-      Metrics.count(METRIC_NAMES.ANCHOR_ACCEPTED, 1, { source: parseOrigin(req) })
+      Metrics.count(METRIC_NAMES.ANCHOR_REQUEST_ACCEPTED, 1, { source: parseOrigin(req) })
       return res.status(StatusCodes.ACCEPTED).json(found)
     } catch (err: any) {
       Metrics.count(METRIC_NAMES.REQUEST_NOT_CREATED, 1, { source: parseOrigin(req) })

--- a/src/controllers/request-controller.ts
+++ b/src/controllers/request-controller.ts
@@ -83,7 +83,7 @@ export class RequestController {
       return res.status(StatusCodes.OK).json(response)
     } catch (err: any) {
       if (err instanceof RequestDoesNotExistError) {
-        Metrics.count(METRIC_NAMES.REQUEST_NOT_FOUND, 1, { source: parseOrigin(req) })
+        Metrics.count(METRIC_NAMES.C_REQUEST_NOT_FOUND, 1, { source: parseOrigin(req) })
         return res.status(StatusCodes.NOT_FOUND).json({
           error: err.message,
         })
@@ -107,7 +107,7 @@ export class RequestController {
     if (isLeft(validation)) {
       const errorMessage = report(validation).join(';')
       logger.err(errorMessage)
-      Metrics.count(METRIC_NAMES.REQUEST_INVALID, 1, { source: parseOrigin(req) })
+      Metrics.count(METRIC_NAMES.C_INVALID_REQUEST, 1, { source: parseOrigin(req) })
       return res.status(StatusCodes.BAD_REQUEST).json({
         error: errorMessage,
       })
@@ -123,7 +123,7 @@ export class RequestController {
 
       // request was newly created
       if (body) {
-        Metrics.count(METRIC_NAMES.ANCHOR_REQUESTED, 1, { source: parseOrigin(req) })
+        Metrics.count(METRIC_NAMES.C_NEW_ANCHOR_REQUEST, 1, { source: parseOrigin(req) })
         return res.status(StatusCodes.CREATED).json(body)
       }
 
@@ -135,10 +135,10 @@ export class RequestController {
         )
       }
       logger.debug(`Found request for ${requestParams.cid} of stream ${requestParams.streamId}`)
-      Metrics.count(METRIC_NAMES.ANCHOR_REQUEST_ACCEPTED, 1, { source: parseOrigin(req) })
+      Metrics.count(METRIC_NAMES.C_FOUND_EXISTING_REQUEST, 1, { source: parseOrigin(req) })
       return res.status(StatusCodes.ACCEPTED).json(found)
     } catch (err: any) {
-      Metrics.count(METRIC_NAMES.REQUEST_NOT_CREATED, 1, { source: parseOrigin(req) })
+      Metrics.count(METRIC_NAMES.C_ERROR_CREATING_REQUEST, 1, { source: parseOrigin(req) })
       return this.getBadRequestResponse(
         res,
         err,

--- a/src/controllers/request-controller.ts
+++ b/src/controllers/request-controller.ts
@@ -83,7 +83,7 @@ export class RequestController {
       return res.status(StatusCodes.OK).json(response)
     } catch (err: any) {
       if (err instanceof RequestDoesNotExistError) {
-        Metrics.count(METRIC_NAMES.C_REQUEST_NOT_FOUND, 1, { source: parseOrigin(req) })
+        Metrics.count(METRIC_NAMES.CTRL_REQUEST_NOT_FOUND, 1, { source: parseOrigin(req) })
         return res.status(StatusCodes.NOT_FOUND).json({
           error: err.message,
         })
@@ -107,7 +107,7 @@ export class RequestController {
     if (isLeft(validation)) {
       const errorMessage = report(validation).join(';')
       logger.err(errorMessage)
-      Metrics.count(METRIC_NAMES.C_INVALID_REQUEST, 1, { source: parseOrigin(req) })
+      Metrics.count(METRIC_NAMES.CTRL_INVALID_REQUEST, 1, { source: parseOrigin(req) })
       return res.status(StatusCodes.BAD_REQUEST).json({
         error: errorMessage,
       })
@@ -123,7 +123,7 @@ export class RequestController {
 
       // request was newly created
       if (body) {
-        Metrics.count(METRIC_NAMES.C_NEW_ANCHOR_REQUEST, 1, { source: parseOrigin(req) })
+        Metrics.count(METRIC_NAMES.CTRL_NEW_ANCHOR_REQUEST, 1, { source: parseOrigin(req) })
         return res.status(StatusCodes.CREATED).json(body)
       }
 
@@ -135,10 +135,10 @@ export class RequestController {
         )
       }
       logger.debug(`Found request for ${requestParams.cid} of stream ${requestParams.streamId}`)
-      Metrics.count(METRIC_NAMES.C_FOUND_EXISTING_REQUEST, 1, { source: parseOrigin(req) })
+      Metrics.count(METRIC_NAMES.CTRL_FOUND_EXISTING_REQUEST, 1, { source: parseOrigin(req) })
       return res.status(StatusCodes.ACCEPTED).json(found)
     } catch (err: any) {
-      Metrics.count(METRIC_NAMES.C_ERROR_CREATING_REQUEST, 1, { source: parseOrigin(req) })
+      Metrics.count(METRIC_NAMES.CTRL_ERROR_CREATING_REQUEST, 1, { source: parseOrigin(req) })
       return this.getBadRequestResponse(
         res,
         err,

--- a/src/services/request-service.ts
+++ b/src/services/request-service.ts
@@ -109,8 +109,10 @@ export class RequestService {
         crt: storedRequest.createdAt,
         org: origin,
       })
+      Metrics.count(METRIC_NAMES.PUBLISH_TO_QUEUE, 1) 
     } else {
       await this.requestRepository.markReplaced(storedRequest)
+      Metrics.count(METRIC_NAMES.UPDATED_STORED_REQUEST, 1)
     }
 
     const did = genesisFields?.controllers?.[0]
@@ -126,6 +128,7 @@ export class RequestService {
       cacao: 'cacaoDomain' in params ? params.cacaoDomain : '',
     };
 
+    // High cardinality business metrics, should be skipped by prometheus
     Metrics.count(METRIC_NAMES.WRITE_TOTAL_TSDB, 1, logData)
 
     logger.debug(`Anchor request received: ${JSON.stringify(logData)}`);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -51,6 +51,8 @@ export enum METRIC_NAMES {
   ANCHOR_REQUESTS_BATCH_TIME = 'anchor_requests_batch_time',
   ANCHOR_REQUESTS_BATCH_FAILURE_TIME = 'anchor_requests_batch_failure_time',
 
+  ANCHOR_REQUEST_ACCEPTED = 'anchor_request_accepted',  // in controller
+
   // *******************************************************************//
   // Request Service
   WRITE_TOTAL_TSDB = 'write_total_tsdb', // note _tsdb implies handles high cardinality

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,13 +1,18 @@
 export enum METRIC_NAMES {
   // *******************************************************************//
+  // All metrics are counts unless noted otherwise
+  // counts are running totals and should be used with rate() or increase()
+
   // Anchor Service (counts)
 
-  // Happy path
-  ACCEPTED_REQUESTS = 'accepted_requests',
-  ANCHOR_SUCCESS = 'anchor_success',
+  // NOTE that anchor service worker metrics are not currently showing up in dev cas
 
-  // Errors and warnings
-  ALREADY_ANCHORED_REQUESTS = 'already_anchored_requests',
+  // Happy path
+  ACCEPTED_REQUESTS = 'accepted_requests', // Anchor service: request candidates accepted
+  ANCHOR_SUCCESS = 'anchor_success',       // Anchor service: requests successfully anchored
+
+  // Anchor Service Errors and warnings
+  ALREADY_ANCHORED_REQUESTS = 'already_anchored_requests', 
   CONFLICTING_REQUESTS = 'conflicting_requests',
   ERROR_IPFS = 'error_ipfs',
   ERROR_MULTIQUERY = 'error_multiquery',
@@ -51,11 +56,12 @@ export enum METRIC_NAMES {
   ANCHOR_REQUESTS_BATCH_TIME = 'anchor_requests_batch_time',
   ANCHOR_REQUESTS_BATCH_FAILURE_TIME = 'anchor_requests_batch_failure_time',
 
-  ANCHOR_REQUEST_ACCEPTED = 'anchor_request_accepted',  // in controller
 
   // *******************************************************************//
   // Request Service
   WRITE_TOTAL_TSDB = 'write_total_tsdb', // note _tsdb implies handles high cardinality
+  // DO NOT change TSDB as it is used downstream
+
   MERKLE_CAR_CACHE_HIT = 'merkle_car_cache_hit',
   MERKLE_CAR_CACHE_MISS = 'merkle_car_cache_miss',
   WITNESS_CAR_CACHE_HIT = 'witness_car_cache_hit',
@@ -73,10 +79,11 @@ export enum METRIC_NAMES {
   IPFS_GET_FAILED = 'ipfs_get_failed',
 
   // Request Controller
-  ANCHOR_REQUESTED = 'anchor_requested',
-  CAR_REQUESTED = 'car_requested',
-  LEGACY_REQUESTED = 'legacy_requested',
-  REQUEST_INVALID = 'request_invalid',
-  REQUEST_NOT_CREATED = 'request_not_created',
-  REQUEST_NOT_FOUND = 'request_not_found',
+  C_NEW_ANCHOR_REQUEST = 'c_new_anchor_request',
+  C_FOUND_EXISTING_REQUEST = 'c_found_existing_request',
+  C_CAR_REQUESTED = 'c_car_requested',
+  C_LEGACY_REQUESTED = 'c_legacy_requested',
+  C_INVALID_REQUEST = 'c_invalid_request',
+  C_ERROR_CREATING_REQUEST = 'c_error_creating_request',
+  C_REQUEST_NOT_FOUND = 'c_request_not_found',
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -60,6 +60,8 @@ export enum METRIC_NAMES {
   MERKLE_CAR_CACHE_MISS = 'merkle_car_cache_miss',
   WITNESS_CAR_CACHE_HIT = 'witness_car_cache_hit',
   WITNESS_CAR_CACHE_MISS = 'witness_car_cache_miss',
+  PUBLISH_TO_QUEUE = 'publish_to_queue',
+  UPDATED_STORED_REQUEST = 'updated_stored_request',
 
   // *******************************************************************//
   // Ceramic Service

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -79,11 +79,11 @@ export enum METRIC_NAMES {
   IPFS_GET_FAILED = 'ipfs_get_failed',
 
   // Request Controller
-  C_NEW_ANCHOR_REQUEST = 'c_new_anchor_request',
-  C_FOUND_EXISTING_REQUEST = 'c_found_existing_request',
-  C_CAR_REQUESTED = 'c_car_requested',
-  C_LEGACY_REQUESTED = 'c_legacy_requested',
-  C_INVALID_REQUEST = 'c_invalid_request',
-  C_ERROR_CREATING_REQUEST = 'c_error_creating_request',
-  C_REQUEST_NOT_FOUND = 'c_request_not_found',
+  CTRL_NEW_ANCHOR_REQUEST = 'ctrl_new_anchor_request',
+  CTRL_FOUND_EXISTING_REQUEST = 'ctrl_found_existing_request',
+  CTRL_CAR_REQUESTED = 'ctrl_car_requested',
+  CTRL_LEGACY_REQUESTED = 'ctrl_legacy_requested',
+  CTRL_INVALID_REQUEST = 'ctrl_invalid_request',
+  CTRL_ERROR_CREATING_REQUEST = 'ctrl_error_creating_request',
+  CTRL_REQUEST_NOT_FOUND = 'ctrl_request_not_found',
 }


### PR DESCRIPTION
# Clarify Metric Names - #WS2-3181

## Description

When exploring metrics in grafana, it is confusing to see similarly named metrics from the controller, scheduler and workers.  Also, some of the existing names were not semantic as to the meaning.

This PR prefixes all controller metrics with 'c_' and clarifies the meanings.  A future PR may prefix the scheduler and anchor workers separately, but these are of interest for now.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ ] Build and unit tests.  Any name mismatches would be caught in teh build.

## Definition of Done

Before submitting this PR, please make sure:

- [ ] If this is merged some grafanas may also need to be updated



## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
