### PR TITLE
use latest version of observability with otlp updates, reduce export …

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -53,8 +53,8 @@
   },
   "metrics": {
     "collectorHost": "",
-    "exportIntervalMillis": 60000,
-    "exportTimeoutMillis": 30000,
+    "exportIntervalMillis": 30000,
+    "exportTimeoutMillis": 20000,
     "prometheusPort": 0
   },
   "db": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@ceramicnetwork/common": "^2.28.0-rc.0",
         "@ceramicnetwork/core": "^2.35.0-rc.0",
         "@ceramicnetwork/logger": "^2.5.0",
-        "@ceramicnetwork/observability": "^1.4.2",
+        "@ceramicnetwork/observability": "^1.4.6",
         "@ceramicnetwork/streamid": "^2.15.0-rc.0",
         "@ceramicnetwork/wasm-bloom-filter": "^0.1.0",
         "@overnightjs/core": "^1.7.6",
@@ -3884,26 +3884,27 @@
       }
     },
     "node_modules/@ceramicnetwork/observability": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/observability/-/observability-1.4.2.tgz",
-      "integrity": "sha512-T4m3Iku2aaFNBLH77z3DCjwKOoTZ+od3MDB0VydVpptcMQSOjxrRdmROt+k9Y3IahFG4yaj3Ai4MpujL8W1RTw==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/observability/-/observability-1.4.7.tgz",
+      "integrity": "sha512-bNPP9zDPYetMZ/Qp6jFdAjqZTUtw0gqztvfxvfzt6cMaX5hcD8zakKyabGQx5HbIMgKlqxXGLOXMTDDKXjwFaw==",
       "dependencies": {
-        "@opentelemetry/api": "1.3.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.41.0",
-        "@opentelemetry/exporter-prometheus": "0.41.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.41.0",
-        "@opentelemetry/resources": "1.15.0",
-        "@opentelemetry/sdk-metrics": "1.15.0",
-        "@opentelemetry/sdk-trace-base": "1.15.0",
-        "@opentelemetry/semantic-conventions": "1.15.0"
+        "@opentelemetry/api": "^1.8.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.50.0",
+        "@opentelemetry/exporter-prometheus": "^0.50.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.50.0",
+        "@opentelemetry/resources": "^1.23.0",
+        "@opentelemetry/sdk-metrics": "^1.23.0",
+        "@opentelemetry/sdk-trace-base": "^1.23.0",
+        "@opentelemetry/semantic-conventions": "^1.23.0",
+        "@types/node": "^20.11.16"
       }
     },
-    "node_modules/@ceramicnetwork/observability/node_modules/@opentelemetry/api": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.3.0.tgz",
-      "integrity": "sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ==",
-      "engines": {
-        "node": ">=8.0.0"
+    "node_modules/@ceramicnetwork/observability/node_modules/@types/node": {
+      "version": "20.12.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@ceramicnetwork/pinning-aggregation": {
@@ -6761,51 +6762,48 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
-      "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+      "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.41.0.tgz",
-      "integrity": "sha512-kopW4ZEKX2mgaPi9jh3lTP+2ixbe0z+tAEOn3v0ZM6jzQl7z+2C1ZZjU1cVYbX+RDGqu7n6BMyv5wmWuqiuKYQ==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.50.0.tgz",
+      "integrity": "sha512-JdZuKrhOYggqOpUljAq4WWNi5nB10PmgoF0y2CvedLGXd0kSawb/UBnWT8gg1ND3bHCNHStAIVT0ELlxJJRqrA==",
       "dependencies": {
-        "@opentelemetry/api": "^1.0.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/api": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.0.tgz",
-      "integrity": "sha512-GGTS6BytfaN8OgbCUOnxg/a9WVsVUj0484zXHZuBzvIXx7V4Tmkb0IHnnhS7Q0cBLNLgjNuvrCpQaP8fIvO4bg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+      "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.41.0.tgz",
-      "integrity": "sha512-YttGW1XEHB9GocXtEY+n0qAT2Ewi/P4l7882kYK4kEl78EAnVvvWvFX1El+TvHA3D2LHDxx9ASu1i+icCqj/Fw==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.50.0.tgz",
+      "integrity": "sha512-DMilj0pTOGxeaRPvVBil/KugvLMV5l+GzoXEWBKXYGEnfNlX+huPeMpYl+zJJBtI3Coht2KArnNOLhs2wqA3yA==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/otlp-exporter-base": "0.41.0",
-        "@opentelemetry/otlp-transformer": "0.41.0",
-        "@opentelemetry/resources": "1.15.0",
-        "@opentelemetry/sdk-metrics": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -6815,14 +6813,13 @@
       }
     },
     "node_modules/@opentelemetry/exporter-prometheus": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.41.0.tgz",
-      "integrity": "sha512-ydoRgNo8CzMNCosyFchfHOV4KlKhEFPFF9uVQD8K2r4VV/AE7uxd8uVj+1uv64YZMjWuxSnNCxJd0VQpDWQFKw==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.50.0.tgz",
+      "integrity": "sha512-6jBrGqzpU1b2gCPUWTSSW+G3ejbZRx9SYhhFg0MO6v8R51mcln9KH6oIdTDrA+3Ie3L18bpygKrIWA9VPWEifg==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/resources": "1.15.0",
-        "@opentelemetry/sdk-metrics": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -6832,16 +6829,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.41.0.tgz",
-      "integrity": "sha512-xG/EJAphB8SFi635vUWJ7rNOwU2nTSIWz1zCu1G6tzQUcej5M1FYtTuUeoJ+HrjHUDOq0SgFbvzfFh6ReggWMQ==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.50.0.tgz",
+      "integrity": "sha512-L7OtIMT7MsFqkmhbQlPBGRXt7152VN5esHpQEJYIBFedOEo3Da+yHpu5ojMZtPzpIvSpB5Xr5lnJUjJCbkttCA==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/otlp-exporter-base": "0.41.0",
-        "@opentelemetry/otlp-transformer": "0.41.0",
-        "@opentelemetry/resources": "1.15.0",
-        "@opentelemetry/sdk-trace-base": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -6851,12 +6847,11 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.41.0.tgz",
-      "integrity": "sha512-fSHtZznIU6kvCLFQC77nOhHj059G1sc/wNl96YiPdro4A8t8ue//ET0yAtpRCQ9lynn4RNrpsw5iEFJszEbmLg==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.50.0.tgz",
+      "integrity": "sha512-JUmjmrCmE1/fc4LjCQMqLfudgSl5OpUkzx7iA94b4jgeODM7zWxUoVXL7/CT7fWf47Cn+pmKjMvTCSESqZZ3mA==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -6866,99 +6861,91 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.41.0.tgz",
-      "integrity": "sha512-a5GqVSdVIhAoYcQrdWQAeMbrkz0iDwKC6BUsuqPuykh+T4QZzrF6cwneOXKbQI5Dl7ms6ha9dYHf4Ka0kc66ZQ==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.50.0.tgz",
+      "integrity": "sha512-s0sl1Yfqd5q1Kjrf6DqXPWzErL+XHhrXOfejh4Vc/SMTNqC902xDsC8JQxbjuramWt/+hibfguIvi7Ns8VLolA==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.41.0",
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/resources": "1.15.0",
-        "@opentelemetry/sdk-logs": "0.41.0",
-        "@opentelemetry/sdk-metrics": "1.15.0",
-        "@opentelemetry/sdk-trace-base": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-logs": "0.50.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+        "@opentelemetry/api": ">=1.3.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.0.tgz",
-      "integrity": "sha512-Sb8A6ZXHXDlgHv32UNRE3y8McWE3vkb5dsSttYArYa5ZpwjiF5ge0vnnKUUnG7bY0AgF9VBIOORZE8gsrnD2WA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.23.0.tgz",
+      "integrity": "sha512-iPRLfVfcEQynYGo7e4Di+ti+YQTAY0h5mQEUJcHlU9JOqpb4x965O6PZ+wMcwYVY63G96KtdS86YCM1BF1vQZg==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/semantic-conventions": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.41.0.tgz",
-      "integrity": "sha512-+Qs8uHcd/tYKS1n6lfSPiQXMOuyPN0c3xKeyWjD5mExRvmA1H6SIYfZmB6KeQNXWODK4z4JtWo5g5Efe0gJ1Vg==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.50.0.tgz",
+      "integrity": "sha512-PeUEupBB29p9nlPNqXoa1PUWNLsZnxG0DCDj3sHqzae+8y76B/A5hvZjg03ulWdnvBLYpnJslqzylG9E0IL87g==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/resources": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.5.0",
+        "@opentelemetry/api": ">=1.4.0 <1.9.0",
         "@opentelemetry/api-logs": ">=0.39.1"
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.15.0.tgz",
-      "integrity": "sha512-fFUnAcPvlXO39nlIduGuaeCuiZyFtSLCn9gW/0djFRO5DFst4m4gcT6+llXvNWuUvtGB49s56NP10B9IZRN0Rw==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.23.0.tgz",
+      "integrity": "sha512-4OkvW6+wST4h6LFG23rXSTf6nmTf201h9dzq7bE0z5R9ESEVLERZz6WXwE7PSgg1gdjlaznm1jLJf8GttypFDg==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/resources": "1.15.0",
-        "lodash.merge": "^4.6.2",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "lodash.merge": "^4.6.2"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+        "@opentelemetry/api": ">=1.3.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.15.0.tgz",
-      "integrity": "sha512-udt1c9VHipbZwvCPIQR1VLg25Z4AMR/g0X8KmcInbFruGWQ/lptVPkz3yvWAsGSta5yHNQ3uoPwcyCygGnQ6Lg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.23.0.tgz",
+      "integrity": "sha512-PzBmZM8hBomUqvCddF/5Olyyviayka44O5nDWq673np3ctnvwMOvNrsUORZjKja1zJbwEuD9niAGbnVrz3jwRQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/resources": "1.15.0",
-        "@opentelemetry/semantic-conventions": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.0.tgz",
-      "integrity": "sha512-f3wwFrFyCpGrFBrFs7lCUJSCSCGyeKG52c+EKeobs3Dd29M75yO6GYkt6PkYPfDawxSlV5p+4yJPPk8tPObzTQ==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.23.0.tgz",
+      "integrity": "sha512-MiqFvfOzfR31t8cc74CTP1OZfz7MbqpAnLCra8NqQoaHJX6ncIRTdYOQYBDQ2uFISDq0WY8Y9dDTWvsgzzBYRg==",
       "engines": {
         "node": ">=14"
       }
@@ -25788,6 +25775,11 @@
         "node": ">=14.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -29752,24 +29744,28 @@
       }
     },
     "@ceramicnetwork/observability": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/observability/-/observability-1.4.2.tgz",
-      "integrity": "sha512-T4m3Iku2aaFNBLH77z3DCjwKOoTZ+od3MDB0VydVpptcMQSOjxrRdmROt+k9Y3IahFG4yaj3Ai4MpujL8W1RTw==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/observability/-/observability-1.4.7.tgz",
+      "integrity": "sha512-bNPP9zDPYetMZ/Qp6jFdAjqZTUtw0gqztvfxvfzt6cMaX5hcD8zakKyabGQx5HbIMgKlqxXGLOXMTDDKXjwFaw==",
       "requires": {
-        "@opentelemetry/api": "1.3.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.41.0",
-        "@opentelemetry/exporter-prometheus": "0.41.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.41.0",
-        "@opentelemetry/resources": "1.15.0",
-        "@opentelemetry/sdk-metrics": "1.15.0",
-        "@opentelemetry/sdk-trace-base": "1.15.0",
-        "@opentelemetry/semantic-conventions": "1.15.0"
+        "@opentelemetry/api": "^1.8.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.50.0",
+        "@opentelemetry/exporter-prometheus": "^0.50.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.50.0",
+        "@opentelemetry/resources": "^1.23.0",
+        "@opentelemetry/sdk-metrics": "^1.23.0",
+        "@opentelemetry/sdk-trace-base": "^1.23.0",
+        "@opentelemetry/semantic-conventions": "^1.23.0",
+        "@types/node": "^20.11.16"
       },
       "dependencies": {
-        "@opentelemetry/api": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.3.0.tgz",
-          "integrity": "sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ=="
+        "@types/node": {
+          "version": "20.12.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+          "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -31930,137 +31926,123 @@
       }
     },
     "@opentelemetry/api": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
-      "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+      "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w=="
     },
     "@opentelemetry/api-logs": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.41.0.tgz",
-      "integrity": "sha512-kopW4ZEKX2mgaPi9jh3lTP+2ixbe0z+tAEOn3v0ZM6jzQl7z+2C1ZZjU1cVYbX+RDGqu7n6BMyv5wmWuqiuKYQ==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.50.0.tgz",
+      "integrity": "sha512-JdZuKrhOYggqOpUljAq4WWNi5nB10PmgoF0y2CvedLGXd0kSawb/UBnWT8gg1ND3bHCNHStAIVT0ELlxJJRqrA==",
       "requires": {
-        "@opentelemetry/api": "^1.0.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/api": "^1.0.0"
       }
     },
     "@opentelemetry/core": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.0.tgz",
-      "integrity": "sha512-GGTS6BytfaN8OgbCUOnxg/a9WVsVUj0484zXHZuBzvIXx7V4Tmkb0IHnnhS7Q0cBLNLgjNuvrCpQaP8fIvO4bg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+      "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/semantic-conventions": "1.23.0"
       }
     },
     "@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.41.0.tgz",
-      "integrity": "sha512-YttGW1XEHB9GocXtEY+n0qAT2Ewi/P4l7882kYK4kEl78EAnVvvWvFX1El+TvHA3D2LHDxx9ASu1i+icCqj/Fw==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.50.0.tgz",
+      "integrity": "sha512-DMilj0pTOGxeaRPvVBil/KugvLMV5l+GzoXEWBKXYGEnfNlX+huPeMpYl+zJJBtI3Coht2KArnNOLhs2wqA3yA==",
       "requires": {
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/otlp-exporter-base": "0.41.0",
-        "@opentelemetry/otlp-transformer": "0.41.0",
-        "@opentelemetry/resources": "1.15.0",
-        "@opentelemetry/sdk-metrics": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0"
       }
     },
     "@opentelemetry/exporter-prometheus": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.41.0.tgz",
-      "integrity": "sha512-ydoRgNo8CzMNCosyFchfHOV4KlKhEFPFF9uVQD8K2r4VV/AE7uxd8uVj+1uv64YZMjWuxSnNCxJd0VQpDWQFKw==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.50.0.tgz",
+      "integrity": "sha512-6jBrGqzpU1b2gCPUWTSSW+G3ejbZRx9SYhhFg0MO6v8R51mcln9KH6oIdTDrA+3Ie3L18bpygKrIWA9VPWEifg==",
       "requires": {
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/resources": "1.15.0",
-        "@opentelemetry/sdk-metrics": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0"
       }
     },
     "@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.41.0.tgz",
-      "integrity": "sha512-xG/EJAphB8SFi635vUWJ7rNOwU2nTSIWz1zCu1G6tzQUcej5M1FYtTuUeoJ+HrjHUDOq0SgFbvzfFh6ReggWMQ==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.50.0.tgz",
+      "integrity": "sha512-L7OtIMT7MsFqkmhbQlPBGRXt7152VN5esHpQEJYIBFedOEo3Da+yHpu5ojMZtPzpIvSpB5Xr5lnJUjJCbkttCA==",
       "requires": {
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/otlp-exporter-base": "0.41.0",
-        "@opentelemetry/otlp-transformer": "0.41.0",
-        "@opentelemetry/resources": "1.15.0",
-        "@opentelemetry/sdk-trace-base": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       }
     },
     "@opentelemetry/otlp-exporter-base": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.41.0.tgz",
-      "integrity": "sha512-fSHtZznIU6kvCLFQC77nOhHj059G1sc/wNl96YiPdro4A8t8ue//ET0yAtpRCQ9lynn4RNrpsw5iEFJszEbmLg==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.50.0.tgz",
+      "integrity": "sha512-JUmjmrCmE1/fc4LjCQMqLfudgSl5OpUkzx7iA94b4jgeODM7zWxUoVXL7/CT7fWf47Cn+pmKjMvTCSESqZZ3mA==",
       "requires": {
-        "@opentelemetry/core": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.23.0"
       }
     },
     "@opentelemetry/otlp-transformer": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.41.0.tgz",
-      "integrity": "sha512-a5GqVSdVIhAoYcQrdWQAeMbrkz0iDwKC6BUsuqPuykh+T4QZzrF6cwneOXKbQI5Dl7ms6ha9dYHf4Ka0kc66ZQ==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.50.0.tgz",
+      "integrity": "sha512-s0sl1Yfqd5q1Kjrf6DqXPWzErL+XHhrXOfejh4Vc/SMTNqC902xDsC8JQxbjuramWt/+hibfguIvi7Ns8VLolA==",
       "requires": {
-        "@opentelemetry/api-logs": "0.41.0",
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/resources": "1.15.0",
-        "@opentelemetry/sdk-logs": "0.41.0",
-        "@opentelemetry/sdk-metrics": "1.15.0",
-        "@opentelemetry/sdk-trace-base": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-logs": "0.50.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.0.tgz",
-      "integrity": "sha512-Sb8A6ZXHXDlgHv32UNRE3y8McWE3vkb5dsSttYArYa5ZpwjiF5ge0vnnKUUnG7bY0AgF9VBIOORZE8gsrnD2WA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.23.0.tgz",
+      "integrity": "sha512-iPRLfVfcEQynYGo7e4Di+ti+YQTAY0h5mQEUJcHlU9JOqpb4x965O6PZ+wMcwYVY63G96KtdS86YCM1BF1vQZg==",
       "requires": {
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/semantic-conventions": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       }
     },
     "@opentelemetry/sdk-logs": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.41.0.tgz",
-      "integrity": "sha512-+Qs8uHcd/tYKS1n6lfSPiQXMOuyPN0c3xKeyWjD5mExRvmA1H6SIYfZmB6KeQNXWODK4z4JtWo5g5Efe0gJ1Vg==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.50.0.tgz",
+      "integrity": "sha512-PeUEupBB29p9nlPNqXoa1PUWNLsZnxG0DCDj3sHqzae+8y76B/A5hvZjg03ulWdnvBLYpnJslqzylG9E0IL87g==",
       "requires": {
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/resources": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0"
       }
     },
     "@opentelemetry/sdk-metrics": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.15.0.tgz",
-      "integrity": "sha512-fFUnAcPvlXO39nlIduGuaeCuiZyFtSLCn9gW/0djFRO5DFst4m4gcT6+llXvNWuUvtGB49s56NP10B9IZRN0Rw==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.23.0.tgz",
+      "integrity": "sha512-4OkvW6+wST4h6LFG23rXSTf6nmTf201h9dzq7bE0z5R9ESEVLERZz6WXwE7PSgg1gdjlaznm1jLJf8GttypFDg==",
       "requires": {
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/resources": "1.15.0",
-        "lodash.merge": "^4.6.2",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "lodash.merge": "^4.6.2"
       }
     },
     "@opentelemetry/sdk-trace-base": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.15.0.tgz",
-      "integrity": "sha512-udt1c9VHipbZwvCPIQR1VLg25Z4AMR/g0X8KmcInbFruGWQ/lptVPkz3yvWAsGSta5yHNQ3uoPwcyCygGnQ6Lg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.23.0.tgz",
+      "integrity": "sha512-PzBmZM8hBomUqvCddF/5Olyyviayka44O5nDWq673np3ctnvwMOvNrsUORZjKja1zJbwEuD9niAGbnVrz3jwRQ==",
       "requires": {
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/resources": "1.15.0",
-        "@opentelemetry/semantic-conventions": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.0.tgz",
-      "integrity": "sha512-f3wwFrFyCpGrFBrFs7lCUJSCSCGyeKG52c+EKeobs3Dd29M75yO6GYkt6PkYPfDawxSlV5p+4yJPPk8tPObzTQ==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.23.0.tgz",
+      "integrity": "sha512-MiqFvfOzfR31t8cc74CTP1OZfz7MbqpAnLCra8NqQoaHJX6ncIRTdYOQYBDQ2uFISDq0WY8Y9dDTWvsgzzBYRg=="
     },
     "@overnightjs/core": {
       "version": "1.7.6",
@@ -46321,6 +46303,11 @@
       "requires": {
         "busboy": "^1.6.0"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@ceramicnetwork/common": "^2.28.0-rc.0",
     "@ceramicnetwork/core": "^2.35.0-rc.0",
     "@ceramicnetwork/logger": "^2.5.0",
-    "@ceramicnetwork/observability": "^1.4.2",
+    "@ceramicnetwork/observability": "^1.4.5",
     "@ceramicnetwork/streamid": "^2.15.0-rc.0",
     "@ceramicnetwork/wasm-bloom-filter": "^0.1.0",
     "@overnightjs/core": "^1.7.6",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@ceramicnetwork/common": "^2.28.0-rc.0",
     "@ceramicnetwork/core": "^2.35.0-rc.0",
     "@ceramicnetwork/logger": "^2.5.0",
-    "@ceramicnetwork/observability": "^1.4.5",
+    "@ceramicnetwork/observability": "^1.4.6",
     "@ceramicnetwork/streamid": "^2.15.0-rc.0",
     "@ceramicnetwork/wasm-bloom-filter": "^0.1.0",
     "@overnightjs/core": "^1.7.6",

--- a/src/__tests__/ceramic_integration.test.ts
+++ b/src/__tests__/ceramic_integration.test.ts
@@ -10,6 +10,7 @@ import {
   expect,
   test,
 } from '@jest/globals'
+
 import { CeramicDaemon, DaemonConfig } from '@ceramicnetwork/cli'
 import { Ceramic } from '@ceramicnetwork/core'
 import { AnchorStatus, fetchJson, IpfsApi, Stream } from '@ceramicnetwork/common'


### PR DESCRIPTION
# update observability packages, reduce export interval - #Infra-39

## Description

The flow of data through the collector has been unreliable.  as a first step, we are upgrading the OTLP exporters, and reducing the default export interval from the OTLP default 60 sec to 30 sec, which may also address a reset artifact we have been seeing after collecting the data

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x ] unit tests in observability package
- [ ] unit tests in CAS



## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
