### PR TITLE
add capability to set an instance identifier which labels all metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,10 @@ RUN npm install
 
 WORKDIR /
 
+COPY entrypoint.sh .
+RUN chmod +x ./entrypoint.sh
+
 COPY runner.sh .
 
+ENTRYPOINT ["./entrypoint.sh"]
 CMD [ "./runner.sh" ]

--- a/config/default.json
+++ b/config/default.json
@@ -55,6 +55,7 @@
     "collectorHost": "",
     "exportIntervalMillis": 30000,
     "exportTimeoutMillis": 20000,
+    "instanceIdentifier": "",
     "prometheusPort": 0
   },
   "db": {

--- a/config/env/dev.json
+++ b/config/env/dev.json
@@ -56,7 +56,7 @@
     "traceRatio": "@@METRICS_TRACE_RATIO",
     "exportIntervalMillis": "@@METRICS_EXPORT_INTERVAL_MS",
     "exportTimeoutMillis": "@@METRICS_EXPORT_TIMEOUT_MS",
-    "instanceIdentifier": "@@ECS_CONTAINER_METADATA_URI",
+    "instanceIdentifier": "@@INSTANCE_IDENTIFIER",
     "prometheusPort": "@@METRICS_PORT"
   },
   "db": {

--- a/config/env/dev.json
+++ b/config/env/dev.json
@@ -56,6 +56,7 @@
     "traceRatio": "@@METRICS_TRACE_RATIO",
     "exportIntervalMillis": "@@METRICS_EXPORT_INTERVAL_MS",
     "exportTimeoutMillis": "@@METRICS_EXPORT_TIMEOUT_MS",
+    "instanceIdentifier": "@@ECS_CONTAINER_METADATA_URI",
     "prometheusPort": "@@METRICS_PORT"
   },
   "db": {

--- a/config/env/prod.json
+++ b/config/env/prod.json
@@ -56,7 +56,7 @@
     "traceRatio": "@@METRICS_TRACE_RATIO",
     "exportIntervalMillis": "@@METRICS_EXPORT_INTERVAL_MS",
     "exportTimeoutMillis": "@@METRICS_EXPORT_TIMEOUT_MS",
-    "instanceIdentifier": "@@ECS_CONTAINER_METADATA_URI",
+    "instanceIdentifier": "@@INSTANCE_IDENTIFIER",
     "prometheusPort": "@@METRICS_PORT"
   },
   "db": {

--- a/config/env/prod.json
+++ b/config/env/prod.json
@@ -56,6 +56,7 @@
     "traceRatio": "@@METRICS_TRACE_RATIO",
     "exportIntervalMillis": "@@METRICS_EXPORT_INTERVAL_MS",
     "exportTimeoutMillis": "@@METRICS_EXPORT_TIMEOUT_MS",
+    "instanceIdentifier": "@@ECS_CONTAINER_METADATA_URI",
     "prometheusPort": "@@METRICS_PORT"
   },
   "db": {

--- a/config/env/test.json
+++ b/config/env/test.json
@@ -37,6 +37,7 @@
     "traceRatio": "@@METRICS_TRACE_RATIO",
     "exportIntervalMillis": "@@METRICS_EXPORT_INTERVAL_MS",
     "exportTimeoutMillis": "@@METRICS_EXPORT_TIMEOUT_MS",
+    "instanceIdentifier": "@@ECS_CONTAINER_METADATA_URI",
     "prometheusPort": "@@METRICS_PORT"
   },
   "db": {

--- a/config/env/test.json
+++ b/config/env/test.json
@@ -37,7 +37,7 @@
     "traceRatio": "@@METRICS_TRACE_RATIO",
     "exportIntervalMillis": "@@METRICS_EXPORT_INTERVAL_MS",
     "exportTimeoutMillis": "@@METRICS_EXPORT_TIMEOUT_MS",
-    "instanceIdentifier": "@@ECS_CONTAINER_METADATA_URI",
+    "instanceIdentifier": "@@INSTANCE_IDENTIFIER",
     "prometheusPort": "@@METRICS_PORT"
   },
   "db": {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+instance_uri=$ECS_CONTAINER_METADATA_URI
+
+# Parse the last portion of the URI
+instance_id=${instance_uri##*/}
+
+# Remove everything after the hyphen to get the task ID
+instance_id=${instance_id%%-*}
+
+# if present, will be the task ID, otherwise empty string
+export INSTANCE_IDENTIFIER=$instance_id
+
+exec "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@ceramicnetwork/common": "^2.28.0-rc.0",
         "@ceramicnetwork/core": "^2.35.0-rc.0",
         "@ceramicnetwork/logger": "^2.5.0",
-        "@ceramicnetwork/observability": "^1.4.6",
+        "@ceramicnetwork/observability": "^1.5.0",
         "@ceramicnetwork/streamid": "^2.15.0-rc.0",
         "@ceramicnetwork/wasm-bloom-filter": "^0.1.0",
         "@overnightjs/core": "^1.7.6",
@@ -3884,9 +3884,9 @@
       }
     },
     "node_modules/@ceramicnetwork/observability": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/observability/-/observability-1.4.7.tgz",
-      "integrity": "sha512-bNPP9zDPYetMZ/Qp6jFdAjqZTUtw0gqztvfxvfzt6cMaX5hcD8zakKyabGQx5HbIMgKlqxXGLOXMTDDKXjwFaw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/observability/-/observability-1.5.0.tgz",
+      "integrity": "sha512-fAcdw0OrAl0LBTan0d9ixER6p558cKPyJkyz7l3/JtBXLjIf3U6Rbf+V4Pf662VNH2Gn69bTnQkA1s0KUV4qhw==",
       "dependencies": {
         "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.50.0",
@@ -29744,9 +29744,9 @@
       }
     },
     "@ceramicnetwork/observability": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/observability/-/observability-1.4.7.tgz",
-      "integrity": "sha512-bNPP9zDPYetMZ/Qp6jFdAjqZTUtw0gqztvfxvfzt6cMaX5hcD8zakKyabGQx5HbIMgKlqxXGLOXMTDDKXjwFaw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/observability/-/observability-1.5.0.tgz",
+      "integrity": "sha512-fAcdw0OrAl0LBTan0d9ixER6p558cKPyJkyz7l3/JtBXLjIf3U6Rbf+V4Pf662VNH2Gn69bTnQkA1s0KUV4qhw==",
       "requires": {
         "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.50.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@ceramicnetwork/common": "^2.28.0-rc.0",
     "@ceramicnetwork/core": "^2.35.0-rc.0",
     "@ceramicnetwork/logger": "^2.5.0",
-    "@ceramicnetwork/observability": "^1.4.6",
+    "@ceramicnetwork/observability": "^1.5.0",
     "@ceramicnetwork/streamid": "^2.15.0-rc.0",
     "@ceramicnetwork/wasm-bloom-filter": "^0.1.0",
     "@overnightjs/core": "^1.7.6",

--- a/src/__tests__/ceramic_integration.test.ts
+++ b/src/__tests__/ceramic_integration.test.ts
@@ -599,7 +599,7 @@ describe('Metrics Options', () => {
       port: casPort,
       useSmartContractAnchors: true,
       metrics: {
-        instanceIdentifier: 'http://127.0.0.1/v3/234fffffffffffffffffffffffffffffffff9726129'
+        instanceIdentifier: '234fffffffffffffffffffffffffffffffff9726129'
       }
     })
     await cas.start()
@@ -613,7 +613,7 @@ describe('Metrics Options', () => {
       port: casPort,
       useSmartContractAnchors: true,
       metrics: {
-        instanceIdentifier: 'fred'
+        instanceIdentifier: ''
       }
     })
     await cas2.start()

--- a/src/__tests__/ceramic_integration.test.ts
+++ b/src/__tests__/ceramic_integration.test.ts
@@ -200,9 +200,6 @@ async function makeCAS(
   configCopy.carStorage = {
     mode: 'inmemory',
   }
-  configCopy.metrics = {
-    instanceIdentifier: 'http://127.0.0.1/v3/234fffffffffffffffffffffffffffffffff9726129'
-  }
   return new CeramicAnchorApp(
     container.provideValue('config', configCopy).provideValue('dbConnection', dbConnection)
   )
@@ -583,6 +580,45 @@ describe('CAR file', () => {
     // Teardown
     await ceramic.close()
     await cas.stop()
+    await ganacheServer.close()
+    await casIPFS.stop()
+  })
+})
+
+describe('Metrics Options', () => {
+  test('cas starts with a typical instance identifier', async () => {
+    const ipfsApiPort = await getPort()
+    const casIPFS = await createIPFS(ipfsApiPort)
+    const ganacheServer = await makeGanache()
+    const dbConnection = await createDbConnection()
+    const casPort = await getPort()
+    const cas = await makeCAS(createInjector(), dbConnection, {
+      mode: 'server',
+      ipfsPort: ipfsApiPort,
+      ganachePort: ganacheServer.port,
+      port: casPort,
+      useSmartContractAnchors: true,
+      metrics: {
+        instanceIdentifier: 'http://127.0.0.1/v3/234fffffffffffffffffffffffffffffffff9726129'
+      }
+    })
+    await cas.start()
+    // Teardown
+    await cas.stop()
+
+    const cas2 = await makeCAS(createInjector(), dbConnection, {
+      mode: 'server',
+      ipfsPort: ipfsApiPort,
+      ganachePort: ganacheServer.port,
+      port: casPort,
+      useSmartContractAnchors: true,
+      metrics: {
+        instanceIdentifier: 'fred'
+      }
+    })
+    await cas2.start()
+    await cas2.stop()
+
     await ganacheServer.close()
     await casIPFS.stop()
   })

--- a/src/__tests__/ceramic_integration.test.ts
+++ b/src/__tests__/ceramic_integration.test.ts
@@ -200,6 +200,9 @@ async function makeCAS(
   configCopy.carStorage = {
     mode: 'inmemory',
   }
+  configCopy.metrics = {
+    instanceIdentifier: 'http://127.0.0.1/v3/234fffffffffffffffffffffffffffffffff9726129'
+  }
   return new CeramicAnchorApp(
     container.provideValue('config', configCopy).provideValue('dbConnection', dbConnection)
   )

--- a/src/app.ts
+++ b/src/app.ts
@@ -135,8 +135,11 @@ export class CeramicAnchorApp {
 
          // in this case, return only the task id following the last /
          const match = this.config.metrics.instanceIdentifier.match(/\/([^\/]*)$/);
-         const instanceId: string = match ? match[1] : this.config.metrics.instanceIdentifier
-         Metrics.setInstanceIdentifier(instanceId)
+         if (match and match[1]) {
+            Metrics.setInstanceIdentifier(match[1])
+         } else {
+            Metrics.setInstanceIdentifier(this.config.metrics.instanceIdentifier)
+         }
       }
     } catch (e: any) {
       logger.imp('ERROR: Metrics exporter failed to start. Continuing anyway.')

--- a/src/app.ts
+++ b/src/app.ts
@@ -135,7 +135,7 @@ export class CeramicAnchorApp {
 
          // in this case, return only the task id following the last /
          const match = this.config.metrics.instanceIdentifier.match(/\/([^\/]*)$/);
-         const instanceId = match ? match[1] : this.config.metrics.instanceIdentifier
+         const instanceId: string = match ? match[1] : this.config.metrics.instanceIdentifier
          Metrics.setInstanceIdentifier(instanceId)
       }
     } catch (e: any) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -129,6 +129,15 @@ export class CeramicAnchorApp {
       )
       Metrics.count('HELLO', 1)
       logger.imp('Metrics exporter started')
+      if (this.config.metrics.instanceIdentifier) {
+         // In the API server, the instanceIdentifer is set from ECS_CONTAINER_METADATA_URI
+         // example value: http://169.254.170.2/v3/234fae8d117d4b76a7af0600b94fc195-2439726129
+
+         // in this case, return only the task id following the last /
+         const match = this.config.metrics.instanceIdentifier.match(/\/([^\/]*)$/);
+         const instanceId = match ? match[1] : this.config.metrics.instanceIdentifier
+         Metrics.setInstanceIdentifier(instanceId)
+      }
     } catch (e: any) {
       logger.imp('ERROR: Metrics exporter failed to start. Continuing anyway.')
       logger.err(e)

--- a/src/app.ts
+++ b/src/app.ts
@@ -134,7 +134,7 @@ export class CeramicAnchorApp {
          // example value: http://169.254.170.2/v3/234fae8d117d4b76a7af0600b94fc195-2439726129
 
          // in this case, return only the task id following the last /
-         const match = this.config.metrics.instanceIdentifier.match(/\/([^\/]*)$/);
+         const match = this.config.metrics.instanceIdentifier.match(/\/([^/]*)$/);
          if (match && match[1]) {
             Metrics.setInstanceIdentifier(match[1])
          } else {

--- a/src/app.ts
+++ b/src/app.ts
@@ -130,16 +130,7 @@ export class CeramicAnchorApp {
       Metrics.count('HELLO', 1)
       logger.imp('Metrics exporter started')
       if (this.config.metrics.instanceIdentifier) {
-         // In the API server, the instanceIdentifer is set from ECS_CONTAINER_METADATA_URI
-         // example value: http://169.254.170.2/v3/234fae8d117d4b76a7af0600b94fc195-2439726129
-
-         // in this case, return only the task id following the last /
-         const match = this.config.metrics.instanceIdentifier.match(/\/([^/]*)$/);
-         if (match && match[1]) {
-            Metrics.setInstanceIdentifier(match[1])
-         } else {
-            Metrics.setInstanceIdentifier(this.config.metrics.instanceIdentifier)
-         }
+         Metrics.setInstanceIdentifier(this.config.metrics.instanceIdentifier)
       }
     } catch (e: any) {
       logger.imp('ERROR: Metrics exporter failed to start. Continuing anyway.')

--- a/src/app.ts
+++ b/src/app.ts
@@ -135,7 +135,7 @@ export class CeramicAnchorApp {
 
          // in this case, return only the task id following the last /
          const match = this.config.metrics.instanceIdentifier.match(/\/([^\/]*)$/);
-         if (match and match[1]) {
+         if (match && match[1]) {
             Metrics.setInstanceIdentifier(match[1])
          } else {
             Metrics.setInstanceIdentifier(this.config.metrics.instanceIdentifier)


### PR DESCRIPTION
# set instance identifier - #WS2-3187
## Description

The current CAS metrics are being sent from the 6 different api nodes with the same name and labels, resulting in inaccurate metrics, stepping on totals, odd reset patterns.  Each instance should have a distinct label.  This PR uses the task id as the label and uses the new observability functionality of Instance Identifier to automatically label all metrics (see https://github.com/ceramicnetwork/observability/pull/29)

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ x] observability package new unit tests
- [ ] unit tests in this pr

## Definition of Done

Before submitting this PR, please make sure:

- [x ] The work addresses the description and outcomes in the issue
- [ x] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
