### PR TITLE
fix: add tests and log when there is an error when persisting anchors

### DIFF
--- a/src/services/__tests__/anchor-service.test.ts
+++ b/src/services/__tests__/anchor-service.test.ts
@@ -378,6 +378,23 @@ describe('anchor service', () => {
     expect(anchors.length).toEqual(numRequests)
   })
 
+  test('Retry persisting anchors on serializable erorr', async () => {
+    const requests = await fake.multipleRequests(4)
+
+    const [candidates] = await anchorService._findCandidates(requests, 0)
+    const merkleTree = await anchorService._buildMerkleTree(candidates)
+    const ipfsProofCid = await ipfsService.storeRecord({})
+    const anchors = await anchorService._createAnchorCommits(ipfsProofCid, merkleTree)
+
+    await Promise.all([
+      requestRepository.updateRequests({ status: RequestStatus.REPLACED }, requests),
+      anchorService._persistAnchorResult(anchors, candidates),
+    ])
+
+    const readyRequests = await requestRepository.findByStatus(RequestStatus.READY)
+    expect(readyRequests.length).toEqual(0)
+  })
+
   describe('Request pinning', () => {
     async function anchorRequests(numRequests: number): Promise<Request[]> {
       // Create Requests
@@ -711,7 +728,7 @@ describe('anchor service', () => {
 
         const batch = new MockQueueMessage({
           bid: uuidv4(),
-          rids: requests.map(({id}) => id),
+          rids: requests.map(({ id }) => id),
         })
         anchorBatchQueueService.receiveMessage.mockReturnValue(Promise.resolve(batch))
 

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -579,6 +579,7 @@ export class AnchorService {
         { isolationLevel: 'repeatable read' }
       )
       .catch(async (err) => {
+        logger.err(`Error persisting anchor results: ${err}`)
         if (err?.code === REPEATED_READ_SERIALIZATION_ERROR) {
           Metrics.count(METRIC_NAMES.DB_SERIALIZATION_ERROR, 1)
           await Utils.delay(100)


### PR DESCRIPTION
i forgot the test when creating the fix (https://github.com/ceramicnetwork/ceramic-anchor-service/pull/1201)