### PR TITLE
remove the high cardinality timescaledb-intended metrics as we get these from logs now

### DIFF
--- a/src/services/request-service.ts
+++ b/src/services/request-service.ts
@@ -128,10 +128,8 @@ export class RequestService {
       cacao: 'cacaoDomain' in params ? params.cacaoDomain : '',
     };
 
-    // High cardinality business metrics, should be skipped by prometheus
-    Metrics.count(METRIC_NAMES.WRITE_TOTAL_TSDB, 1, logData)
-
-    logger.debug(`Anchor request received: ${JSON.stringify(logData)}`);
+    // DO NOT REMOVE - this logging is used by business metrics
+    logger.imp(`Anchor request received: ${JSON.stringify(logData)}`);
 
     return this.requestPresentationService.body(storedRequest)
   }


### PR DESCRIPTION
# Remove the TSDB metrics - #INFRA-39

## Description

The metrics ending in _tsdb were intended to be routed thru promscale container and directed to timescaledb; however, this had not worked reliably and we actually get them from logs instead.  Removing this path entirely as it might be bogging down the collectors.  

Also adjusted the priority of the business metric logging from `debug` to `imp` as a signal that we should not remove or change it without carefully looking at dependencies.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ ] Unit tests

## Definition of Done

Before submitting this PR, please make sure:

- [ ] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
