### PR TITLE
fix: exit runner scripts explicitly once completed

### DIFF
--- a/runner/report-exit.js
+++ b/runner/report-exit.js
@@ -16,6 +16,7 @@ async function main() {
 main()
   .then(() => {
     console.log('Done')
+    process.exit(0)
   })
   .catch((error) => {
     console.error(error)

--- a/runner/report-failure.js
+++ b/runner/report-failure.js
@@ -16,6 +16,7 @@ async function main() {
 main()
   .then(() => {
     console.log('Done')
+    process.exit(0)
   })
   .catch((error) => {
     console.error(error)

--- a/runner/report-start.js
+++ b/runner/report-start.js
@@ -17,6 +17,7 @@ async function main() {
 main()
   .then(() => {
     console.log('Done')
+    process.exit(0)
   })
   .catch((error) => {
     console.error(error)


### PR DESCRIPTION
Explicitly exit the runner scripts once they are complete.