### PR TITLE
feat: cas scaling ph 2 (s3 batching)

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -84,6 +84,8 @@
     "type": "sqs",
     "awsRegion": "us-east-1",
     "sqsQueueUrl": "",
+    "s3BucketName": "myS3Bucket",
+    "s3Endpoint": "",
     "maxTimeToHoldMessageSec": 21600,
     "waitTimeForMessageSec": 0
   }

--- a/config/env/dev.json
+++ b/config/env/dev.json
@@ -79,6 +79,8 @@
     "type": "sqs",
     "awsRegion": "@@AWS_REGION",
     "sqsQueueUrl": "@@SQS_QUEUE_URL",
+    "s3BucketName": "@@S3_BUCKET_NAME",
+    "s3Endpoint": "@@S3_ENDPOINT",
     "maxTimeToHoldMessageSec": "@@MAX_TIME_TO_HOLD_MESSAGE_SEC",
     "waitTimeForMessageSec": "@@WAIT_TIME_FOR_MESSAGE_SEC"
   }

--- a/config/env/prod.json
+++ b/config/env/prod.json
@@ -79,6 +79,8 @@
     "type": "sqs",
     "awsRegion": "@@AWS_REGION",
     "sqsQueueUrl": "@@SQS_QUEUE_URL",
+    "s3BucketName": "@@S3_BUCKET_NAME",
+    "s3Endpoint": "@@S3_ENDPOINT",
     "maxTimeToHoldMessageSec": "@@MAX_TIME_TO_HOLD_MESSAGE_SEC",
     "waitTimeForMessageSec": "@@WAIT_TIME_FOR_MESSAGE_SEC"
   }

--- a/config/env/test.json
+++ b/config/env/test.json
@@ -61,6 +61,7 @@
     "type": "sqs",
     "awsRegion": "us-east-1",
     "sqsQueueUrl": "",
+    "s3BucketName": "ceramic-tnet-cas",
     "maxTimeToHoldMessageSec": 10800,
     "waitTimeForMessageSec": 10
   }

--- a/src/services/anchor-service.ts
+++ b/src/services/anchor-service.ts
@@ -217,7 +217,7 @@ export class AnchorService {
     }
 
     try {
-      logger.imp('Anchoring requests from the batch')
+      logger.imp(`Anchoring ${batchMessage.data.rids.length} requests from batch ${batchMessage.data.bid}`)
       const requests = await this.requestRepository.findByIds(batchMessage.data.rids)
 
       const requestsNotReplaced = requests.filter(


### PR DESCRIPTION
Allow workers to be able to pull anchor batches from S3, with fallback to existing logic for extracting batches from SQS messages.

This needs to be merged before S3 batching in the Scheduler is merged, since this code is backward-compatible and capable of handling both types of batching strategies.