### PR TITLE
feat: batch db calls when loading candidates

### DIFF
--- a/src/repositories/anchor-repository.ts
+++ b/src/repositories/anchor-repository.ts
@@ -4,6 +4,7 @@ import type { Knex } from 'knex'
 import type { AnchorWithRequest, IAnchorRepository } from './anchor-repository.type.js'
 import { parseCountResult } from './parse-count-result.util.js'
 import { decode } from 'codeco'
+import { request } from 'https'
 
 const TABLE_NAME = 'anchor'
 
@@ -56,5 +57,16 @@ export class AnchorRepository implements IAnchorRepository {
     const row = await this.table.where({ requestId: requestId }).first()
     if (!row) return null
     return decode(StoredAnchor, row)
+  }
+
+  async findByRequests(requests: Request[]): Promise<AnchorWithRequest[]> {
+    const rows = await this.table.whereIn(
+      'requestId',
+      requests.map((r) => r.id)
+    )
+    return rows.map((row) => {
+      const anchor = decode(StoredAnchor, row)
+      return { ...anchor, request }
+    })
   }
 }

--- a/src/repositories/anchor-repository.ts
+++ b/src/repositories/anchor-repository.ts
@@ -64,7 +64,7 @@ export class AnchorRepository implements IAnchorRepository {
       'requestId',
       requests.map((r) => r.id)
     )
-    return rows.map((row) => {
+    return rows.map((row: StoredAnchor) => {
       const anchor = decode(StoredAnchor, row)
       return { ...anchor, request }
     })

--- a/src/repositories/anchor-repository.type.ts
+++ b/src/repositories/anchor-repository.type.ts
@@ -11,4 +11,5 @@ export interface IAnchorRepository {
   findByRequest(request: Request): Promise<AnchorWithRequest | null>
   findByRequestId(id: string): Promise<StoredAnchor | null>
   withConnection(connection: Knex): IAnchorRepository
+  findByRequests(requests: Request[]): Promise<AnchorWithRequest[]>
 }

--- a/src/repositories/metadata-repository.ts
+++ b/src/repositories/metadata-repository.ts
@@ -26,6 +26,10 @@ export interface IMetadataRepository {
    * Mark an entry as used `now`. Return true if touched, i.e. if the entry was in the database.
    */
   touch(streamId: StreamID, now?: Date): Promise<boolean>
+  /**
+   * Find all entries for the given `streamIds`. Return an empty array if none found.
+   */
+  batchRetrieve(streamIds: StreamID[]): Promise<StoredMetadata[]>
 }
 
 /**
@@ -89,5 +93,16 @@ export class MetadataRepository implements IMetadataRepository {
       .where({ streamId: streamIdAsString.encode(streamId) })
       .update({ usedAt: date.encode(now) })
     return rowsTouched > 0
+  }
+
+  /**
+   * Find all entries for the given `streamIds`. Return an empty array if none found.
+   */
+  async batchRetrieve(streamIds: StreamID[]): Promise<StoredMetadata[]> {
+    const rows = await this.table.whereIn(
+      'streamId',
+      streamIds.map((s) => s.toString())
+    )
+    return rows.map((row: any) => decode(StoredMetadata, row))
   }
 }

--- a/src/services/metadata-service.ts
+++ b/src/services/metadata-service.ts
@@ -16,6 +16,7 @@ export interface IMetadataService {
   fill(streamId: StreamID, genesisFields: GenesisFields): Promise<void>
   fillFromIpfs(streamId: StreamID, options?: AbortOptions): Promise<GenesisFields>
   retrieve(streamId: StreamID): Promise<StoredMetadata | undefined>
+  batchRetrieve(streamIds: StreamID[]): Promise<StoredMetadata[]>
 }
 
 /**
@@ -101,6 +102,10 @@ export class MetadataService implements IMetadataService {
 
   async retrieve(streamId: StreamID): Promise<StoredMetadata | undefined> {
     return this.metadataRepository.retrieve(streamId)
+  }
+
+  async batchRetrieve(streamIds: StreamID[]): Promise<StoredMetadata[]> {
+    return this.metadataRepository.batchRetrieve(streamIds)
   }
 
   /**


### PR DESCRIPTION
Currently we loop through each request and retrieve the metadata for it, and check if there is an anchor for it. Instead of doing this per request, we can do one batch call to do it before processing. 