### PR TITLE
feat: reuse connections in http client + increase max sockets

### DIFF
--- a/src/services/queue/sqs-queue-service.ts
+++ b/src/services/queue/sqs-queue-service.ts
@@ -128,8 +128,8 @@ export class SqsQueueService<TValue extends QueueMessageData>
       requestHandler: new NodeHttpHandler({
         httpAgent: new http.Agent({
           keepAlive: true,
-          maxSockets: 50,
-          maxFreeSockets: 20,
+          maxSockets: 1000,
+          maxFreeSockets: 768,
         }),
       }),
     })

--- a/src/services/queue/sqs-queue-service.ts
+++ b/src/services/queue/sqs-queue-service.ts
@@ -128,8 +128,6 @@ export class SqsQueueService<TValue extends QueueMessageData>
       requestHandler: new NodeHttpHandler({
         httpAgent: new http.Agent({
           keepAlive: true,
-          maxSockets: 1000,
-          maxFreeSockets: 768,
         }),
       }),
     })

--- a/src/services/queue/sqs-queue-service.ts
+++ b/src/services/queue/sqs-queue-service.ts
@@ -21,6 +21,8 @@ import { AnchorBatchQMessage, RequestQMessage } from '../../models/queue-message
 import { Codec, decode } from 'codeco'
 import { AbortOptions } from '@ceramicnetwork/common'
 import { logger } from '../../logger/index.js'
+import * as http from 'http'
+import { NodeHttpHandler } from '@smithy/node-http-handler'
 
 const DEFAULT_MAX_TIME_TO_HOLD_MESSAGES_S = 21600
 const DEFAULT_WAIT_TIME_FOR_MESSAGE_S = 10
@@ -123,6 +125,13 @@ export class SqsQueueService<TValue extends QueueMessageData>
       region: config.queue.awsRegion,
       endpoint: this.sqsQueueUrl,
       logger: awsLogger,
+      requestHandler: new NodeHttpHandler({
+        httpAgent: new http.Agent({
+          keepAlive: true,
+          maxSockets: 50,
+          maxFreeSockets: 20,
+        }),
+      }),
     })
     this.maxTimeToHoldMessageSec =
       config.queue.maxTimeToHoldMessageSec || DEFAULT_MAX_TIME_TO_HOLD_MESSAGES_S


### PR DESCRIPTION
# [Scale SQS] - #[Issue]

## Description

SQS sendMessages  is taking  >3 minutes. We are increasing the number of socket connections sqs can make and adding a config to allow it to reuse connections.

## References:
https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-configuring-maxsockets.html

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
